### PR TITLE
fix PG_AUTOCTL_MAX_TIMELINES

### DIFF
--- a/src/bin/pg_autoctl/pgsql.h
+++ b/src/bin/pg_autoctl/pgsql.h
@@ -193,7 +193,7 @@ typedef struct NodeAddressArray
 #define InvalidXLogRecPtr 0
 #define XLogRecPtrIsInvalid(r) ((r) == InvalidXLogRecPtr)
 
-#define PG_AUTOCTL_MAX_TIMELINES 1024
+#define PG_AUTOCTL_MAX_TIMELINES 1048576
 
 typedef struct TimeLineHistoryEntry
 {


### PR DESCRIPTION
ERROR history file "00000202.history" contains 1024 lines, pg_autoctl only supports up to 1023 lines
https://github.com/hapostgres/pg_auto_failover/issues/991