### PR TITLE
Fix history file parsing.

### DIFF
--- a/src/bin/pg_autoctl/string_utils.c
+++ b/src/bin/pg_autoctl/string_utils.c
@@ -496,6 +496,43 @@ IntervalToString(double seconds, char *buffer, size_t size)
 
 
 /*
+ * countLines returns how many line separators (\n) are found in the given
+ * string.
+ */
+int
+countLines(char *buffer)
+{
+	int lineNumber = 0;
+	char *currentLine = buffer;
+
+	if (buffer == NULL)
+	{
+		return 0;
+	}
+
+	do {
+		char *newLinePtr = strchr(currentLine, '\n');
+
+		if (newLinePtr == NULL)
+		{
+			if (strlen(currentLine) > 0)
+			{
+				++lineNumber;
+			}
+			currentLine = NULL;
+		}
+		else
+		{
+			++lineNumber;
+			currentLine = ++newLinePtr;
+		}
+	} while (currentLine != NULL && *currentLine != '\0');
+
+	return lineNumber;
+}
+
+
+/*
  * splitLines prepares a multi-line error message in a way that calling code
  * can loop around one line at a time and call log_error() or log_warn() on
  * individual lines.

--- a/src/bin/pg_autoctl/string_utils.h
+++ b/src/bin/pg_autoctl/string_utils.h
@@ -37,6 +37,7 @@ bool stringToUInt32(const char *str, uint32_t *number);
 bool stringToDouble(const char *str, double *number);
 bool IntervalToString(double seconds, char *buffer, size_t size);
 
+int countLines(char *buffer);
 int splitLines(char *errorMessage, char **linesArray, int size);
 void processBufferCallback(const char *buffer, bool error);
 


### PR DESCRIPTION
The previous coding used a statically allocated array of pointers to newlines in that file, limiting our parsing abilities to files of 1024 lines maximum. Apparently that's not a good limit, so use dynamically allocated memory instead.

Fixes #991.