### PR TITLE
Fix build with Postgres 166 libpq-dev in debian.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,6 +23,7 @@ jobs:
           - 13
           - 14
           - 15
+          - 16
         TEST:
           - multi
           - single

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,9 @@ PGVERSION ?= 14
 BUILD_ARGS_PG11 = --build-arg PGVERSION=11 --build-arg CITUSTAG=v9.5.10
 BUILD_ARGS_PG12 = --build-arg PGVERSION=12 --build-arg CITUSTAG=v10.2.9
 BUILD_ARGS_PG13 = --build-arg PGVERSION=13 --build-arg CITUSTAG=v10.2.9
-BUILD_ARGS_PG14 = --build-arg PGVERSION=14 --build-arg CITUSTAG=v11.2.1
-BUILD_ARGS_PG15 = --build-arg PGVERSION=15 --build-arg CITUSTAG=v11.2.1
+BUILD_ARGS_PG14 = --build-arg PGVERSION=14 --build-arg CITUSTAG=v12.1.0
+BUILD_ARGS_PG15 = --build-arg PGVERSION=15 --build-arg CITUSTAG=v12.1.0
+BUILD_ARGS_PG16 = --build-arg PGVERSION=16 --build-arg CITUSTAG=v12.1.0
 
 NOSETESTS = $(shell which nosetests3 || which nosetests)
 
@@ -279,6 +280,9 @@ build-test-pg14: version
 build-test-pg15: version
 	docker build $(BUILD_ARGS_PG15) --target test -t $(TEST_CONTAINER_NAME):pg15 .
 
+build-test-pg16: version
+	docker build $(BUILD_ARGS_PG16) --target test -t $(TEST_CONTAINER_NAME):pg16 .
+
 
 build-test-image: build-test-pg$(PGVERSION) ;
 
@@ -310,10 +314,13 @@ build-pg14: build-test-pg14
 build-pg15: build-test-pg15
 	docker build $(BUILD_ARGS_PG15) -t $(CONTAINER_NAME):pg15 .
 
-build: build-pg11 build-pg12 build-pg13 build-pg14 build-pg15 ;
+build-pg16: build-test-pg16
+	docker build $(BUILD_ARGS_PG16) -t $(CONTAINER_NAME):pg16 .
+
+build: build-pg11 build-pg12 build-pg13 build-pg14 build-pg15 build-pg16 ;
 
 build-check:
-	for v in 11 12 13 14 15; do \
+	for v in 11 12 13 14 15 16; do \
 		docker run --rm -t pg_auto_failover_test:pg$$v pg_autoctl version --json | jq ".pg_version" | xargs echo $$v: ; \
 	done
 

--- a/src/bin/lib/pg/snprintf.c
+++ b/src/bin/lib/pg/snprintf.c
@@ -338,36 +338,18 @@ static void leading_pad(int zpad, int signvalue, int *padlen,
 						PrintfTarget *target);
 static void trailing_pad(int padlen, PrintfTarget *target);
 
-/*
- * If strchrnul exists (it's a glibc-ism), it's a good bit faster than the
- * equivalent manual loop.  If it doesn't exist, provide a replacement.
- *
- * Note: glibc declares this as returning "char *", but that would require
- * casting away const internally, so we don't follow that detail.
- */
-#ifndef HAVE_STRCHRNUL
 
+/*
+ * While Postgres sources do it the smart way and check HAVE_STRCHRNUL from the
+ * auto-configure output, we just use the Postgres version of strchrnul here.
+ */
 static inline const char *
-strchrnul(const char *s, int c)
+pg_strchrnul(const char *s, int c)
 {
 	while (*s != '\0' && *s != c)
 		s++;
 	return s;
 }
-
-#else
-
-/*
- * glibc's <string.h> declares strchrnul only if _GNU_SOURCE is defined.
- * While we typically use that on glibc platforms, configure will set
- * HAVE_STRCHRNUL whether it's used or not.  Fill in the missing declaration
- * so that this file will compile cleanly with or without _GNU_SOURCE.
- */
-#ifndef _GNU_SOURCE
-extern char *strchrnul(const char *s, int c);
-#endif
-
-#endif							/* HAVE_STRCHRNUL */
 
 
 /*
@@ -412,7 +394,7 @@ dopr(PrintfTarget *target, const char *format, va_list args)
 		if (*format != '%')
 		{
 			/* Scan to next '%' or end of string */
-			const char *next_pct = strchrnul(format + 1, '%');
+			const char *next_pct = pg_strchrnul(format + 1, '%');
 
 			/* Dump literal data we just scanned over */
 			dostr(format, next_pct - format, target);

--- a/src/bin/pg_autoctl/azure.c
+++ b/src/bin/pg_autoctl/azure.c
@@ -1585,9 +1585,9 @@ azure_fetch_resource_list(const char *group, AzureRegionResources *azRegion)
 			}
 			else if (streq(type, "Microsoft.Compute/virtualMachines"))
 			{
-				int index = azure_node_index_from_name(group, name);
+				int idx = azure_node_index_from_name(group, name);
 
-				strlcpy(azRegion->vmArray[index].name, name, NAMEDATALEN);
+				strlcpy(azRegion->vmArray[idx].name, name, NAMEDATALEN);
 
 				log_info("Found existing VM \"%s\"", name);
 			}

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -1524,7 +1524,7 @@ keeper_cli_print_version(int argc, char **argv)
 				"pg_autoctl extension version %s\n",
 				PG_AUTOCTL_EXTENSION_VERSION);
 		fformat(stdout, "compiled with %s\n", PG_VERSION_STR);
-		fformat(stdout, "compatible with Postgres 11, 12, 13, 14, and 15\n");
+		fformat(stdout, "compatible with Postgres 11, 12, 13, 14, 15, and 16\n");
 	}
 
 	exit(0);

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1837,9 +1837,6 @@ pg_log_startup(const char *pgdata, int logLevel)
 		 */
 		if (pgLogFileMtime >= pgStartupMtime)
 		{
-			char *fileContents;
-			long fileSize;
-
 			log_level(pathLogLevel,
 					  "Postgres logs from \"%s\":", pgLogFilePath);
 

--- a/src/bin/pg_autoctl/pgsetup.c
+++ b/src/bin/pg_autoctl/pgsetup.c
@@ -501,7 +501,7 @@ get_pgpid(PostgresSetup *pgSetup, bool pgIsNotRunningIsOk)
 		}
 		else
 		{
-			int logLevel = pgIsNotRunningIsOk ? LOG_DEBUG : LOG_WARN;
+			logLevel = pgIsNotRunningIsOk ? LOG_DEBUG : LOG_WARN;
 
 			log_level(logLevel,
 					  "Read a stale pid in \"postmaster.pid\": %d", pid);

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -1239,7 +1239,7 @@ postgres_maybe_do_crash_recovery(LocalPostgresServer *postgres)
 				 * Now stop Postgres by just killing our child process, and
 				 * wait until the child process has finished with waitpid().
 				 */
-				int wpid, status;
+				int wpid;
 
 				do {
 					if (kill(fpid, SIGTERM) != 0)

--- a/src/bin/pg_autoctl/watch.c
+++ b/src/bin/pg_autoctl/watch.c
@@ -1430,7 +1430,7 @@ print_event(WatchContext *context, EventColPolicy *policy, int index, int r, int
 			case EVENT_COLUMN_TYPE_DESCRIPTION:
 			{
 				char *text = event->description;
-				int len = strlen(text);
+				len = strlen(text);
 
 				/* when KEY_END is used, ensure we see the end of text */
 				if (context->move == WATCH_MOVE_FOCUS_END)

--- a/src/monitor/node_active_protocol.c
+++ b/src/monitor/node_active_protocol.c
@@ -867,7 +867,7 @@ get_nodes(PG_FUNCTION_ARGS)
 		/* prepare next SRF call */
 		fctx->nodesList = list_delete_first(fctx->nodesList);
 
-		SRF_RETURN_NEXT(funcctx, PointerGetDatum(resultDatum));
+		SRF_RETURN_NEXT(funcctx, resultDatum);
 	}
 
 	SRF_RETURN_DONE(funcctx);
@@ -995,7 +995,7 @@ get_other_nodes(PG_FUNCTION_ARGS)
 		/* prepare next SRF call */
 		fctx->nodesList = list_delete_first(fctx->nodesList);
 
-		SRF_RETURN_NEXT(funcctx, PointerGetDatum(resultDatum));
+		SRF_RETURN_NEXT(funcctx, resultDatum);
 	}
 
 	SRF_RETURN_DONE(funcctx);
@@ -1132,7 +1132,6 @@ RemoveNode(AutoFailoverNode *currentNode, bool force)
 	{
 		foreach(nodeCell, otherNodesGroupList)
 		{
-			char message[BUFSIZE] = { 0 };
 			AutoFailoverNode *node = (AutoFailoverNode *) lfirst(nodeCell);
 
 			if (node == NULL)
@@ -1712,7 +1711,6 @@ start_maintenance(PG_FUNCTION_ARGS)
 	{
 		List *standbyNodesGroupList = AutoFailoverOtherNodesList(currentNode);
 		AutoFailoverNode *firstStandbyNode = linitial(standbyNodesGroupList);
-		char message[BUFSIZE] = { 0 };
 
 		/*
 		 * We need at least one candidate node to initiate a failover and allow

--- a/src/monitor/node_metadata.c
+++ b/src/monitor/node_metadata.c
@@ -1255,9 +1255,9 @@ AddAutoFailoverNode(char *formationId,
 			" max(nodeid)+1) "
 			" FROM " AUTO_FAILOVER_NODE_TABLE;
 
-		int spiStatus = SPI_execute_with_args(setValQuery,
-											  0, NULL, NULL, NULL,
-											  false, 0);
+		spiStatus = SPI_execute_with_args(setValQuery,
+										  0, NULL, NULL, NULL,
+										  false, 0);
 
 		if (spiStatus != SPI_OK_SELECT)
 		{

--- a/src/monitor/pg_auto_failover.c
+++ b/src/monitor/pg_auto_failover.c
@@ -124,12 +124,14 @@ StartMonitorNode(void)
 	DefineCustomBoolVariable("pgautofailover.enable_version_checks",
 							 "Enable extension version compatibility checks",
 							 NULL, &EnableVersionChecks, true, PGC_SIGHUP,
-							 GUC_NO_SHOW_ALL, NULL, NULL, NULL);
+							 GUC_NO_SHOW_ALL & GUC_NOT_IN_SAMPLE,
+							 NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("pgautofailover.enable_health_checks",
 							 "Enable background health checks",
 							 NULL, &HealthChecksEnabled, true, PGC_SIGHUP,
-							 GUC_NO_SHOW_ALL, NULL, NULL, NULL);
+							 GUC_NO_SHOW_ALL & GUC_NOT_IN_SAMPLE,
+							 NULL, NULL, NULL);
 
 	DefineCustomIntVariable("pgautofailover.health_check_period",
 							"Duration between each check (in milliseconds).",

--- a/src/monitor/pg_auto_failover.c
+++ b/src/monitor/pg_auto_failover.c
@@ -124,13 +124,13 @@ StartMonitorNode(void)
 	DefineCustomBoolVariable("pgautofailover.enable_version_checks",
 							 "Enable extension version compatibility checks",
 							 NULL, &EnableVersionChecks, true, PGC_SIGHUP,
-							 GUC_NO_SHOW_ALL & GUC_NOT_IN_SAMPLE,
+							 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 							 NULL, NULL, NULL);
 
 	DefineCustomBoolVariable("pgautofailover.enable_health_checks",
 							 "Enable background health checks",
 							 NULL, &HealthChecksEnabled, true, PGC_SIGHUP,
-							 GUC_NO_SHOW_ALL & GUC_NOT_IN_SAMPLE,
+							 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE,
 							 NULL, NULL, NULL);
 
 	DefineCustomIntVariable("pgautofailover.health_check_period",

--- a/src/monitor/version_compat.h
+++ b/src/monitor/version_compat.h
@@ -14,8 +14,8 @@
 
 #include "postgres.h"
 
-/* we support Postgres versions 10, 11, 12, 13, and 14. And 15devel. */
-#if (PG_VERSION_NUM < 100000 || PG_VERSION_NUM >= 160000)
+/* we support Postgres versions 10, 11, 12, 13, 14, 15, and 16. */
+#if (PG_VERSION_NUM < 100000 || PG_VERSION_NUM >= 170000)
 #error "Unknown or unsupported postgresql version"
 #endif
 
@@ -74,6 +74,17 @@ HeapTupleGetOid(HeapTuple tuple)
 
 /* Compatibility for ProcessUtility hook */
 #define QueryCompletion char
+
+#endif
+
+/* Removed in Postgres 16 development */
+#ifndef Abs
+
+/*
+ * Abs
+ *		Return the absolute value of the argument.
+ */
+#define Abs(x) ((x) >= 0 ? (x) : -(x))
 
 #endif
 


### PR DESCRIPTION
Build passes locally with a released version of Postgres 16.0 and still builds with previous version. Still missing CI changes to pass all the test suite with PGVERSION=16.

Fixes #1005.