### PR TITLE
Update makefile

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
           - 13
           - 14
           - 15
-          - 16
+          # - 16 # FIXME pg16 should be supported but main still does not work with it.
         TEST:
           - multi
           - single

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,8 @@ ENV PG_CONFIG /usr/lib/postgresql/${PGVERSION}/bin/pg_config
 WORKDIR /usr/src/pg_auto_failover
 
 COPY Makefile ./
+COPY Makefile.azure ./
+COPY Makefile.citus ./
 COPY ./src/ ./src
 COPY ./src/bin/pg_autoctl/git-version.h ./src/bin/pg_autoctl/git-version.h
 RUN make -s clean && make -s install -j8

--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -23,6 +23,8 @@ RUN pip3 install sphinx_rtd_theme
 WORKDIR /usr/src/pg_auto_failover
 
 COPY Makefile ./
+COPY Makefile.azure ./
+COPY Makefile.citus ./
 COPY ./src ./src
 COPY ./docs ./docs
 

--- a/Dockerfile.i386
+++ b/Dockerfile.i386
@@ -56,6 +56,8 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 WORKDIR /usr/src/pg_auto_failover
 
 COPY Makefile ./
+COPY Makefile.azure ./
+COPY Makefile.citus ./
 COPY ./src/ ./src
 RUN make -s clean && make -s install
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ PGVERSIONS = 11 12 13 14 15 16
 # Default version:
 PGVERSION ?= $(lastword $(PGVERSIONS))
 
+# XXXX This should be in Makefile.citus only
+# but requires to clean up dockerfile and make targets related to citus first.
+# Default Citus Data version
+CITUSTAG ?= v12.1.0
+
 # TODO should be abs_top_dir ?
 TOP := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -254,6 +259,10 @@ DOCKER_RUN_OPTS = --privileged --rm
 #
 # Include Citus only for testing purpose
 #
+ifeq ($(TEST),citus)
+  CITUS=1
+endif
+
 ifeq ($(CITUS),1)
 include Makefile.citus
 endif

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ PGVERSIONS = 11 12 13 14 15 16
 # Default version:
 PGVERSION ?= $(lastword $(PGVERSIONS))
 
+# PostgreSQL cluster option
+# could be "--skip-pg-hba"
+CLUSTER_OPTS = ""
+
 # XXXX This should be in Makefile.citus only
 # but requires to clean up dockerfile and make targets related to citus first.
 # Default Citus Data version
@@ -359,6 +363,7 @@ TMUX_EXTRA_COMMANDS ?= ""
 TMUX_LAYOUT ?= even-vertical	# could be "tiled"
 TMUX_TOP_DIR = ./tmux/pgsql
 TMUX_SCRIPT = ./tmux/script-$(FIRST_PGPORT).tmux
+TMUX_CITUS = ""
 
 # PostgreSQL testing
 ## total count of Postgres nodes
@@ -369,10 +374,6 @@ NODES_ASYNC ?= 0
 NODES_PRIOS ?= 50
 ## TODO ???
 NODES_SYNC_SB ?= -1
-## Citus workers (set in Makefile.citus)
-WORKERS = 0
-## Citus secondaries (set in Makefile.citus)
-NODES_SECONDARY = 0
 
 .PHONY: interactive-test
 interactive-test:
@@ -388,8 +389,7 @@ $(TMUX_SCRIPT): bin
          --async-nodes $(NODES_ASYNC)     \
          --node-priorities $(NODES_PRIOS) \
          --sync-standbys $(NODES_SYNC_SB) \
-         --citus-workers $(WORKERS) \
-         --citus-secondaries $(NODES_SECONDARY) \
+         $(TMUX_CITUS)                    \
          $(CLUSTER_OPTS)                  \
          --binpath $(BINPATH)             \
 		 --layout $(TMUX_LAYOUT) > $@
@@ -403,8 +403,7 @@ tmux-clean: bin
          --root $(TMUX_TOP_DIR)           \
          --first-pgport $(FIRST_PGPORT)   \
          --nodes $(NODES)                 \
-         --citus-workers $(WORKERS)       \
-         --citus-secondaries $(NODES_SECONDARY) \
+         $(TMUX_CITUS)                    \
          $(CLUSTER_OPTS)
 
 .PHONY: tmux-session
@@ -416,8 +415,7 @@ tmux-session: bin
          --async-nodes $(NODES_ASYNC)     \
          --node-priorities $(NODES_PRIOS) \
          --sync-standbys $(NODES_SYNC_SB) \
-         --citus-workers $(WORKERS)       \
-         --citus-secondaries $(NODES_SECONDARY) \
+         $(TMUX_CITUS)                    \
          $(CLUSTER_OPTS)                  \
          --binpath $(BINPATH)             \
          --layout $(TMUX_LAYOUT)
@@ -431,8 +429,7 @@ tmux-compose-session:
          --async-nodes $(NODES_ASYNC)     \
          --node-priorities $(NODES_PRIOS) \
          --sync-standbys $(NODES_SYNC_SB) \
-         --citus-workers $(WORKERS)       \
-         --citus-secondaries $(NODES_SECONDARY) \
+         $(TMUX_CITUS)                    \
          $(CLUSTER_OPTS)                  \
          --binpath $(BINPATH)             \
          --layout $(TMUX_LAYOUT)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the PostgreSQL License.
 
+.DEFAULT_GOAL := all
+
 # Supported PostgreSQL versions:
 PGVERSIONS = 11 12 13 14 15 16
 

--- a/Makefile
+++ b/Makefile
@@ -136,24 +136,6 @@ else
 	TMUX_TOP_DIR = ./tmux/pgsql
 endif
 
-# make azcluster arguments
-AZURE_PREFIX ?= ha-demo-$(shell whoami)
-AZURE_REGION ?= paris
-AZURE_LOCATION ?= francecentral
-
-# Pick a version of Postgres and pg_auto_failover packages to install
-# in our target Azure VMs when provisionning
-#
-#  sudo apt-get install -q -y postgresql-13-auto-failover-1.5=1.5.2
-#  postgresql-${AZ_PG_VERSION}-auto-failover-${AZ_PGAF_DEB_VERSION}=${AZ_PGAF_VERSION}
-AZ_PG_VERSION ?= 13
-AZ_PGAF_DEB_VERSION ?= 1.6
-AZ_PGAF_DEB_REVISION ?= 1.6.4-1
-
-export AZ_PG_VERSION
-export AZ_PGAF_DEB_VERSION
-export AZ_PGAF_DEB_REVISION
-
 all: monitor bin ;
 
 install: install-monitor install-bin ;
@@ -432,23 +414,10 @@ valgrind-session: build-test-pg$(PGVERSION)
 		 TMUX_LAYOUT=$(TMUX_LAYOUT)        \
 	     tmux-session
 
-azcluster: all
-	$(PG_AUTOCTL) do azure create         \
-         --prefix $(AZURE_PREFIX)         \
-         --region $(AZURE_REGION)         \
-         --location $(AZURE_LOCATION)     \
-         --nodes $(NODES)
-
-# make azcluster has been done before, just re-attach
-az: all
-	$(PG_AUTOCTL) do azure tmux session
-
-azdrop: all
-	$(PG_AUTOCTL) do azure drop
+include Makefile.azure
 
 .PHONY: all clean check install docs tikz
 .PHONY: monitor clean-monitor check-monitor install-monitor
 .PHONY: bin clean-bin install-bin maintainer-clean
 .PHONY: run-test spellcheck lint linting ci-test
 .PHONY: tmux-clean cluster compose
-.PHONY: azcluster azdrop az

--- a/Makefile
+++ b/Makefile
@@ -306,11 +306,17 @@ $(BUILD_TARGETS): version
 .PHONY: build
 build: $(BUILD_TARGETS) ;
 
+BUILD_CHECK_TARGETS = $(patsubst %,build-check-pg%,$(PGVERSIONS))
+
+.SECONDEXPANSION:
+.PHONY: $(BUILD_CHECK_TARGETS)
+$(BUILD_CHECK_TARGETS): version $$(subst build-check-,build-test-,$$@)
+	docker run --rm \
+	  -t pg_auto_failover_test:$(subst build-check-,,$@) \
+	  pg_autoctl version --json | jq ".pg_version" | xargs echo $(subst build-check-,,$@):
+
 .PHONY: build-check
-build-check: $(BUILD_TEST_TARGETS)
-	for v in $(PGVERSIONS); do \
-		docker run --rm -t pg_auto_failover_test:pg$$v pg_autoctl version --json | jq ".pg_version" | xargs echo $$v: ; \
-	done
+build-check: $(BUILD_CHECK_TARGETS)
 
 .PHONY: build-i386
 build-i386:

--- a/Makefile.azure
+++ b/Makefile.azure
@@ -1,0 +1,38 @@
+#
+# AZURE related
+#
+
+# make azcluster arguments
+AZURE_PREFIX ?= ha-demo-$(shell whoami)
+AZURE_REGION ?= paris
+AZURE_LOCATION ?= francecentral
+
+# Pick a version of Postgres and pg_auto_failover packages to install
+# in our target Azure VMs when provisionning
+#
+#  sudo apt-get install -q -y postgresql-13-auto-failover-1.5=1.5.2
+#  postgresql-${AZ_PG_VERSION}-auto-failover-${AZ_PGAF_DEB_VERSION}=${AZ_PGAF_VERSION}
+AZ_PG_VERSION ?= 13
+AZ_PGAF_DEB_VERSION ?= 1.6
+AZ_PGAF_DEB_REVISION ?= 1.6.4-1
+
+export AZ_PG_VERSION
+export AZ_PGAF_DEB_VERSION
+export AZ_PGAF_DEB_REVISION
+
+.PHONY: azcluster
+azcluster: all
+	$(PG_AUTOCTL) do azure create      \
+	  --prefix $(AZURE_PREFIX)         \
+	  --region $(AZURE_REGION)         \
+	  --location $(AZURE_LOCATION)     \
+	  --nodes $(NODES)
+
+# make azcluster has been done before, just re-attach
+.PHONY: az
+az: all
+	$(PG_AUTOCTL) do azure tmux session
+
+.PHONY: azdrop
+azdrop: all
+	$(PG_AUTOCTL) do azure drop

--- a/Makefile.citus
+++ b/Makefile.citus
@@ -5,7 +5,6 @@ CITUSTAG ?= v12.1.0
 CITUS = 0
 WORKERS = 2
 NODES_SECONDARY = 0
-CLUSTER_OPTS = ""			# could be "--skip-pg-hba"
 
 FIRST_PGPORT ?= 5600
 CLUSTER_OPTS += --citus
@@ -22,3 +21,6 @@ ifeq ($(TEST),citus)
 
   TEST_ARGUMENT = --where=tests --tests=$(TESTS_CITUS)
 endif
+
+# this target is defined and used later in the main Makefile
+$(TMUX_SCRIPT): TMUX_CITUS=--citus-workers $(WORKERS) --citus-secondaries $(NODES_SECONDARY)

--- a/Makefile.citus
+++ b/Makefile.citus
@@ -1,0 +1,24 @@
+# Default Citus Data version
+CITUSTAG ?= v12.1.0
+
+# Citus testing
+CITUS = 0
+WORKERS = 2
+NODES_SECONDARY = 0
+CLUSTER_OPTS = ""			# could be "--skip-pg-hba"
+
+FIRST_PGPORT ?= 5600
+CLUSTER_OPTS += --citus
+TMUX_TOP_DIR = ./tmux/citus
+
+# If this Makefile is included then we are only interested in Citus testing
+ifeq ($(TEST),citus)
+  TESTS_CITUS  = test_basic_citus_operation
+  TESTS_CITUS += test_citus_cluster_name
+  TESTS_CITUS += test_citus_force_failover
+  TESTS_CITUS += test_citus_multi_standbys
+  TESTS_CITUS += test_nonha_citus_operation
+  TESTS_CITUS += test_citus_skip_pg_hba
+
+  TEST_ARGUMENT = --where=tests --tests=$(TESTS_CITUS)
+endif

--- a/docs/citus/Dockerfile
+++ b/docs/citus/Dockerfile
@@ -52,6 +52,8 @@ RUN apt-get update \
 WORKDIR /usr/src/pg_auto_failover
 
 COPY Makefile ./
+COPY Makefile.azure ./
+COPY Makefile.citus ./
 COPY src/ ./src
 RUN make -s clean && make -s install -j8
 RUN cp /usr/lib/postgresql/${PGVERSION}/bin/pg_autoctl /usr/local/bin

--- a/docs/tutorial/Dockerfile
+++ b/docs/tutorial/Dockerfile
@@ -43,6 +43,8 @@ RUN apt-get update \
 WORKDIR /usr/src/pg_auto_failover
 
 COPY Makefile ./
+COPY Makefile.azure ./
+COPY Makefile.citus ./
 COPY src/ ./src
 RUN make -s clean && make -s install -j8
 RUN cp /usr/lib/postgresql/${PGVERSION}/bin/pg_autoctl /usr/local/bin


### PR DESCRIPTION
This PR does:

* sort/organize the main Makefile
* move on their own makefile citus and azure things
* make sure .PHONY is defined when needed
* add some new targets per pg version (following  the same -pgXX suffix)
* fix some missing targets and missing dependency (some might still need attention)
* IMPORTANT: now use ".SECONDEXPANSION" to allow more generic target/prerequisites.
* removed pg16 from GHA until main is fixed.