### PR TITLE
Postgres sixteen version

### DIFF
--- a/src/monitor/health_check.h
+++ b/src/monitor/health_check.h
@@ -55,8 +55,8 @@ extern int HealthCheckRetryDelay;
 extern size_t HealthCheckWorkerShmemSize(void);
 
 extern void InitializeHealthCheckWorker(void);
-extern void HealthCheckWorkerMain(Datum arg);
-extern void HealthCheckWorkerLauncherMain(Datum arg);
+extern PGDLLEXPORT void HealthCheckWorkerMain(Datum arg);
+extern PGDLLEXPORT void HealthCheckWorkerLauncherMain(Datum arg);
 extern List * LoadNodeHealthList(void);
 extern NodeHealth * TupleToNodeHealth(HeapTuple heapTuple,
 									  TupleDesc tupleDescriptor);

--- a/src/monitor/health_check_worker.c
+++ b/src/monitor/health_check_worker.c
@@ -414,6 +414,8 @@ RegisterHealthCheckWorker(DatabaseListEntry *db)
 			sizeof(worker.bgw_library_name));
 	strlcpy(worker.bgw_function_name, "HealthCheckWorkerMain",
 			sizeof(worker.bgw_function_name));
+	strlcpy(worker.bgw_type, "pgautofailover",
+			sizeof(worker.bgw_type));
 	appendStringInfo(&buf, "pg_auto_failover monitor healthcheck worker %s",
 					 db->dbname);
 	strlcpy(worker.bgw_name, buf.data,

--- a/src/monitor/pg_auto_failover.c
+++ b/src/monitor/pg_auto_failover.c
@@ -195,6 +195,7 @@ StartMonitorNode(void)
 	strlcpy(worker.bgw_name, "pg_auto_failover monitor", sizeof(worker.bgw_name));
 	strlcpy(worker.bgw_function_name, "HealthCheckWorkerLauncherMain",
 			sizeof(worker.bgw_function_name));
+	strlcpy(worker.bgw_type, "pgautofailover", sizeof(worker.bgw_type));
 
 	RegisterBackgroundWorker(&worker);
 }


### PR DESCRIPTION
 Add PGDLLEXPORT markings in exported bgworker functions

From postgres version 16 onward it is necessary for exported background worker
functions to be marked PGDLLEXPORT. Otherwise they are not findable by
LookupBackgroundWorkerFunction().

Failing to mark healthcheck entry point functions as such leads to a miss
functioning monitor as the child processes will fail to launch yet the monitor
will be running.

Adding the markings to previous postgres versions does not have any adverse
symptoms. Hence this commit adds them unconditionally.

While at it, improve the log messages by defining bgw_type.
