### PR TITLE
Reactivate Github CI tests for Postgres major version 16

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
           - 13
           - 14
           - 15
-          # - 16 # FIXME pg16 should be supported but main still does not work with it.
+          - 16
         TEST:
           - multi
           - single


### PR DESCRIPTION
Commit ae5fa55c4a deactivated the related tests due to failures. Commit 6698a7d07ca addressed the failures yet it did not re-activate the CI tests. This commit amends that.