### PR TITLE
update Dockerfile for pg_auto_failover/docs/tutorial

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # target version of Postgres. In the Makefile, we use that to our advantage
 # and tag test images such as pg_auto_failover_test:pg14.
 #
-ARG PGVERSION=14
+ARG PGVERSION=16
 
 #
 # Define a base image with all our build dependencies.
@@ -84,7 +84,7 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 FROM base as citus
 
 ARG PGVERSION
-ARG CITUSTAG=v11.1.2
+ARG CITUSTAG=v12.1.0
 
 ENV PG_CONFIG /usr/lib/postgresql/${PGVERSION}/bin/pg_config
 


### PR DESCRIPTION
Current `Dockerfile` use postgresql 14 and citus 11.1.2 which will cause following errors when build:
+ `/usr/src/citus/src/include/pg_version_compat.h:59:1: error: redefinition of 'RelationGetSmgr'`
+ `/usr/include/postgresql/internal/libpq-int.h:86:10: fatal error: common/pg_prng.h: No such file or directory`

The first error has been fixed since citus 11.1.6 and the `pg_prng.h` exists since postgresql 15.

Update postgresql version to 16 and citus version 12.1.0 can fixed above two errors:
```
tutorial=# select version();   
                                                           version                                                           
-----------------------------------------------------------------------------------------------------------------------------
 PostgreSQL 16.1 (Debian 16.1-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
(1 row)

```