### PR TITLE
Add support for PostgreSQL 17

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,6 +22,7 @@ jobs:
           - 14
           - 15
           - 16
+          - 17
         TEST:
           - multi
           - single
@@ -51,7 +52,7 @@ jobs:
           pip3 install --user black
           black --version
           gcc --version
-          git clone -b v0.8.19 --depth 1 https://github.com/citusdata/tools.git ../tools
+          git clone -b v0.8.31 --depth 1 https://github.com/citusdata/tools.git ../tools
           sudo make -C ../tools install
           install_uncrustify
           rm -rf uncrustify*

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .DEFAULT_GOAL := all
 
 # Supported PostgreSQL versions:
-PGVERSIONS = 13 14 15 16
+PGVERSIONS = 13 14 15 16 17
 
 # Default version:
 PGVERSION ?= $(lastword $(PGVERSIONS))
@@ -276,6 +276,7 @@ BUILD_ARGS_pg13 = --build-arg PGVERSION=13 --build-arg CITUSTAG=v10.2.9
 BUILD_ARGS_pg14 = --build-arg PGVERSION=14 --build-arg CITUSTAG=$(CITUSTAG)
 BUILD_ARGS_pg15 = --build-arg PGVERSION=15 --build-arg CITUSTAG=$(CITUSTAG)
 BUILD_ARGS_pg16 = --build-arg PGVERSION=16 --build-arg CITUSTAG=$(CITUSTAG)
+BUILD_ARGS_pg17 = --build-arg PGVERSION=17 --build-arg CITUSTAG=$(CITUSTAG)
 
 # DOCKER BUILDS
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ $ sudo apt-get install postgresql-16-auto-failover
 When using debian, two packages are provided for pg_auto_failover: the
 monitor Postgres extension is packaged separately and depends on the
 Postgres version you want to run for the monitor itself. The monitor's
-extension package is named `postgresql-14-auto-failover` when targeting
-Postgres 14.
+extension package is named `postgresql-16-auto-failover` when targeting
+Postgres 16.
 
 Then another package is prepared that contains the `pg_autoctl` command, and
 the name of the package is `pg-auto-failover-cli`. That's the package that
@@ -85,12 +85,12 @@ follow these steps before installing the previous packages.
 
 ```bash
 $ curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-$ echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+$ echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
 # bypass initdb of a "main" cluster
 $ echo 'create_main_cluster = false' | sudo tee -a /etc/postgresql-common/createcluster.conf
 $ apt-get update
-$ apt-get install -y --no-install-recommends postgresql-14
+$ apt-get install -y --no-install-recommends postgresql-16
 ```
 
 ### Other installation methods

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ install by following the linked documentation and then::
 
 ```bash
 $ sudo apt-get install pg-auto-failover-cli
-$ sudo apt-get install postgresql-16-auto-failover
+$ sudo apt-get install postgresql-17-auto-failover
 ```
 
 When using debian, two packages are provided for pg_auto_failover: the
 monitor Postgres extension is packaged separately and depends on the
 Postgres version you want to run for the monitor itself. The monitor's
-extension package is named `postgresql-16-auto-failover` when targeting
-Postgres 16.
+extension package is named `postgresql-17-auto-failover` when targeting
+Postgres 17.
 
 Then another package is prepared that contains the `pg_autoctl` command, and
 the name of the package is `pg-auto-failover-cli`. That's the package that
@@ -90,7 +90,7 @@ $ echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/a
 # bypass initdb of a "main" cluster
 $ echo 'create_main_cluster = false' | sudo tee -a /etc/postgresql-common/createcluster.conf
 $ apt-get update
-$ apt-get install -y --no-install-recommends postgresql-16
+$ apt-get install -y --no-install-recommends postgresql-17
 ```
 
 ### Other installation methods

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 pg_auto_failover is an extension and service for PostgreSQL that monitors
 and manages automated failover for a Postgres cluster. It is optimized for
-simplicity and correctness and supports Postgres 13 and newer.
+simplicity and correctness and supports Postgres 13 to 17.
 
 pg_auto_failover supports several Postgres architectures and implements a
 safe automated failover for your Postgres service. It is possible to get

--- a/docs/azure-tutorial.rst
+++ b/docs/azure-tutorial.rst
@@ -154,7 +154,7 @@ nodes. It will help us run and observe PostgreSQL.
         "curl https://install.citusdata.com/community/deb.sh | sudo bash" \
         "sudo DEBIAN_FRONTEND=noninteractive apt-get install -q -y postgresql-common" \
         "echo 'create_main_cluster = false' | sudo tee -a /etc/postgresql-common/createcluster.conf" \
-        "sudo DEBIAN_FRONTEND=noninteractive apt-get install -q -y postgresql-16-auto-failover" \
+        "sudo DEBIAN_FRONTEND=noninteractive apt-get install -q -y postgresql-17-auto-failover" \
         "sudo usermod -a -G postgres ha-admin" &
   done
   wait
@@ -178,7 +178,7 @@ own roles in the system.
        --auth trust \
        --ssl-self-signed \
        --pgdata monitor \
-       --pgctl /usr/lib/postgresql/16/bin/pg_ctl
+       --pgctl /usr/lib/postgresql/17/bin/pg_ctl
 
 This command initializes a PostgreSQL cluster at the location pointed
 by the ``--pgdata`` option. When ``--pgdata`` is omitted, ``pg_autoctl``
@@ -225,7 +225,7 @@ We’ll create the primary database using the ``pg_autoctl create`` subcommand.
        --username ha-admin \
        --dbname appdb \
        --hostname ha-demo-a.internal.cloudapp.net \
-       --pgctl /usr/lib/postgresql/16/bin/pg_ctl \
+       --pgctl /usr/lib/postgresql/17/bin/pg_ctl \
        --monitor 'postgres://autoctl_node@ha-demo-monitor.internal.cloudapp.net/pg_auto_failover?sslmode=require'
 
 Notice the user and database name in the monitor connection string -- these
@@ -274,7 +274,7 @@ Next connect to node B and do the same process. We'll do both steps at once:
        --username ha-admin \
        --dbname appdb \
        --hostname ha-demo-b.internal.cloudapp.net \
-       --pgctl /usr/lib/postgresql/16/bin/pg_ctl \
+       --pgctl /usr/lib/postgresql/17/bin/pg_ctl \
        --monitor 'postgres://autoctl_node@ha-demo-monitor.internal.cloudapp.net/pg_auto_failover?sslmode=require'
 
    ssh -T -l ha-admin `vm_ip b` << CMD

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,8 +6,8 @@ Installing pg_auto_failover
 We provide native system packages for pg_auto_failover on most popular Linux
 distributions.
 
-Use the steps below to install pg_auto_failover on PostgreSQL 16. At the
-current time pg_auto_failover is compatible with PostgreSQL 13 to 16.
+Use the steps below to install pg_auto_failover on PostgreSQL 17. At the
+current time pg_auto_failover is compatible with PostgreSQL 13 and newer.
 
 Ubuntu or Debian
 ----------------
@@ -20,13 +20,13 @@ Binary packages for debian and derivatives (ubuntu) are available from
 documentation and then::
 
   $ sudo apt-get install pg-auto-failover-cli
-  $ sudo apt-get install postgresql-16-auto-failover
+  $ sudo apt-get install postgresql-17-auto-failover
 
 __ https://wiki.postgresql.org/wiki/Apt
 
 The Postgres extension named "pgautofailover" is only necessary on the
 monitor node. To install that extension, you can install the
-``postgresql-16-auto-failover`` package when using Postgres 16. It's
+``postgresql-17-auto-failover`` package when using Postgres 17. It's
 available for other Postgres versions too.
 
 Avoiding the default Postgres service
@@ -42,12 +42,12 @@ debian package, follow those steps:
 ::
 
   $ curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-  $ echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+  $ echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 
   # bypass initdb of a "main" cluster
   $ echo 'create_main_cluster = false' | sudo tee -a /etc/postgresql-common/createcluster.conf
   $ apt-get update
-  $ apt-get install -y --no-install-recommends postgresql-14
+  $ apt-get install -y --no-install-recommends postgresql-17
 
 That way when it's time to :ref:`pg_autoctl_create_monitor` or
 :ref:`pg_autoctl_create_postgres` there is no confusion about how to handle
@@ -91,7 +91,7 @@ Here's a sample output from the command:
    WorkingDirectory = /var/lib/postgresql
    Environment = 'PGDATA=/var/lib/postgresql/monitor'
    User = postgres
-   ExecStart = /usr/lib/postgresql/10/bin/pg_autoctl run
+   ExecStart = /usr/lib/postgresql/17/bin/pg_autoctl run
    Restart = always
    StartLimitBurst = 0
 
@@ -128,7 +128,7 @@ pg_auto_failover uses the same build dependencies:
 
 ::
 
-   $ sudo apt-get build-dep -y --no-install-recommends postgresql-14
+   $ sudo apt-get build-dep -y --no-install-recommends postgresql-17
 
 Then build pg_auto_failover from sources with the following instructions:
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,7 +7,7 @@ We provide native system packages for pg_auto_failover on most popular Linux
 distributions.
 
 Use the steps below to install pg_auto_failover on PostgreSQL 17. At the
-current time pg_auto_failover is compatible with PostgreSQL 13 and newer.
+current time pg_auto_failover is compatible with PostgreSQL 13 to 17.
 
 Ubuntu or Debian
 ----------------

--- a/src/bin/pg_autoctl/azure.c
+++ b/src/bin/pg_autoctl/azure.c
@@ -1055,10 +1055,10 @@ azure_build_pg_autoctl(AzureRegionResources *azRegion)
 	pid_t pidArray[MAX_VMS_PER_REGION] = { 0 };
 
 	char *buildCommand =
-		"make PG_CONFIG=/usr/lib/postgresql/16/bin/pg_config "
+		"make PG_CONFIG=/usr/lib/postgresql/17/bin/pg_config "
 		"-C pg_auto_failover -s clean all "
 		" && "
-		"sudo make PG_CONFIG=/usr/lib/postgresql/16/bin/pg_config "
+		"sudo make PG_CONFIG=/usr/lib/postgresql/17/bin/pg_config "
 		"BINDIR=/usr/local/bin -C pg_auto_failover install";
 
 	log_info("Building pg_auto_failover from sources on %d Azure VMs",

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -1524,7 +1524,7 @@ keeper_cli_print_version(int argc, char **argv)
 				"pg_autoctl extension version %s\n",
 				PG_AUTOCTL_EXTENSION_VERSION);
 		fformat(stdout, "compiled with %s\n", PG_VERSION_STR);
-		fformat(stdout, "compatible with Postgres 13, 14, 15, and 16\n");
+		fformat(stdout, "compatible with Postgres 13, 14, 15, 16 and 17\n");
 	}
 
 	exit(0);

--- a/src/bin/pg_autoctl/pgctl.c
+++ b/src/bin/pg_autoctl/pgctl.c
@@ -1569,12 +1569,12 @@ pg_ctl_initdb(const char *pg_ctl, const char *pgdata)
 	log_info("Initialising a PostgreSQL cluster at \"%s\"", pgdata);
 	log_info("%s initdb -s -D %s --option '--auth=trust'", pg_ctl, pgdata);
 
-	Program program = run_program(pg_ctl, "initdb",
+	Program program = run_program(pg_ctl,
 								  "--silent",
 								  "--pgdata", pgdata,
 
 	                              /* avoid warning message */
-								  "--option", "'--auth=trust'",
+								  "--option", "'--auth=trust'", "initdb",
 								  NULL);
 
 	bool success = program.returnCode == 0;
@@ -1944,8 +1944,8 @@ pg_ctl_stop(const char *pg_ctl, const char *pgdata)
 	Program program = run_program(pg_ctl,
 								  "--pgdata", pgdata,
 								  "--wait",
-								  "stop",
 								  "--mode", "fast",
+								  "stop",
 								  NULL);
 
 	/*
@@ -2009,7 +2009,7 @@ pg_ctl_stop(const char *pg_ctl, const char *pgdata)
 int
 pg_ctl_status(const char *pg_ctl, const char *pgdata, bool log_output)
 {
-	Program program = run_program(pg_ctl, "status", "-D", pgdata, NULL);
+	Program program = run_program(pg_ctl, "-D", pgdata, "status", NULL);
 	int returnCode = program.returnCode;
 
 	log_level(log_output ? LOG_INFO : LOG_DEBUG,
@@ -2032,7 +2032,7 @@ bool
 pg_ctl_promote(const char *pg_ctl, const char *pgdata)
 {
 	Program program =
-		run_program(pg_ctl, "promote", "-D", pgdata, "--no-wait", NULL);
+		run_program(pg_ctl, "-D", pgdata, "--no-wait", "promote", NULL);
 	int returnCode = program.returnCode;
 
 	log_debug("%s promote -D %s --no-wait", pg_ctl, pgdata);

--- a/src/monitor/version_compat.h
+++ b/src/monitor/version_compat.h
@@ -14,8 +14,8 @@
 
 #include "postgres.h"
 
-/* we support Postgres versions 10, 11, 12, 13, 14, 15, and 16. */
-#if (PG_VERSION_NUM < 100000 || PG_VERSION_NUM >= 170000)
+/* we support Postgres versions 10, 11, 12, 13, 14, 15, 16, and 17. */
+#if (PG_VERSION_NUM < 100000 || PG_VERSION_NUM >= 180000)
 #error "Unknown or unsupported postgresql version"
 #endif
 


### PR DESCRIPTION
Added build support and test matrix entry for v17. Updated `citusdata/tools`. Dropped v10 support over the board since it was inconsistent in multiple files.

I also changed Debian buster and v14 to bookworm and v16 in the README to reference the current versions.

Fixes #1048.