### PR TITLE
Fix make compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # target version of Postgres. In the Makefile, we use that to our advantage
 # and tag test images such as pg_auto_failover_test:pg14.
 #
-ARG PGVERSION=14
+ARG PGVERSION=17
 
 #
 # Define a base image with all our build dependencies.
@@ -18,18 +18,18 @@ RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
-	curl \
-	gnupg \
-	git \
-	gawk \
-	flex \
-	bison \
+    curl \
+    gnupg \
+    git \
+    gawk \
+    flex \
+    bison \
     iproute2 \
-	libcurl4-gnutls-dev \
-	libicu-dev \
-	libncurses-dev \
-	libxml2-dev \
-	zlib1g-dev \
+    libcurl4-gnutls-dev \
+    libicu-dev \
+    libncurses-dev \
+    libxml2-dev \
+    zlib1g-dev \
     libedit-dev \
     libkrb5-dev \
     liblz4-dev \
@@ -41,16 +41,16 @@ RUN apt-get update \
     libxslt1-dev \
     libzstd-dev \
     uuid-dev \
-	make \
-	autoconf \
+    make \
+    autoconf \
     openssl \
     pipenv \
     python3-nose \
     python3 \
-	python3-setuptools \
-	python3-psycopg2 \
+    python3-setuptools \
+    python3-psycopg2 \
     python3-pip \
-	sudo \
+    sudo \
     tmux \
     watch \
     lsof \
@@ -58,10 +58,10 @@ RUN apt-get update \
     psmisc \
     htop \
     less \
-	mg \
+    mg \
     valgrind \
     postgresql-common \
-	&& rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/*
 
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main ${PGVERSION}" > /etc/apt/sources.list.d/pgdg.list
@@ -84,7 +84,7 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 FROM base AS citus
 
 ARG PGVERSION
-ARG CITUSTAG=v11.1.2
+ARG CITUSTAG=v13.0.1
 
 ENV PG_CONFIG=/usr/lib/postgresql/${PGVERSION}/bin/pg_config
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CLUSTER_OPTS = ""
 # XXXX This should be in Makefile.citus only
 # but requires to clean up dockerfile and make targets related to citus first.
 # Default Citus Data version
-CITUSTAG ?= v13.0.0
+CITUSTAG ?= v13.0.1
 
 # TODO should be abs_top_dir ?
 TOP := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -273,8 +273,8 @@ endif
 
 # We use pg not PG in uppercase in the var name to ease implicit rules matching
 BUILD_ARGS_pg13 = --build-arg PGVERSION=13 --build-arg CITUSTAG=v10.2.9
-BUILD_ARGS_pg14 = --build-arg PGVERSION=14 --build-arg CITUSTAG=$(CITUSTAG)
-BUILD_ARGS_pg15 = --build-arg PGVERSION=15 --build-arg CITUSTAG=$(CITUSTAG)
+BUILD_ARGS_pg14 = --build-arg PGVERSION=14 --build-arg CITUSTAG=v12.1.5
+BUILD_ARGS_pg15 = --build-arg PGVERSION=15 --build-arg CITUSTAG=v12.1.5
 BUILD_ARGS_pg16 = --build-arg PGVERSION=16 --build-arg CITUSTAG=$(CITUSTAG)
 BUILD_ARGS_pg17 = --build-arg PGVERSION=17 --build-arg CITUSTAG=$(CITUSTAG)
 

--- a/Makefile.citus
+++ b/Makefile.citus
@@ -1,5 +1,5 @@
 # Default Citus Data version
-CITUSTAG ?= v13.0.0
+CITUSTAG ?= v13.0.1
 
 # Citus testing
 CITUS = 0


### PR DESCRIPTION
The change from "docker-compose" to "docker compose" was broken.

Also it turns out we need to have the CITUSTAG to PGVERSION compat matrix around when preparing the "docker compose build" command line.