### PR TITLE
Allow monitor node binary upgrades with pg_upgrade

### DIFF
--- a/src/monitor/pg_auto_failover.c
+++ b/src/monitor/pg_auto_failover.c
@@ -75,6 +75,15 @@ PG_MODULE_MAGIC;
 void
 _PG_init(void)
 {
+	/* Check PostgreSQL's internal binary upgrade flag */
+	extern bool IsBinaryUpgrade;
+	if (IsBinaryUpgrade)
+	{
+		ereport(LOG,
+				(errmsg("pgautofailover: skipping initialization during binary upgrade")));
+		return;
+	}
+
 	if (!process_shared_preload_libraries_in_progress)
 	{
 		ereport(ERROR,


### PR DESCRIPTION
Allow monitor node binary upgrades with pg_upgrade by skipping extension startup if a binary upgrade is detected.

Without this fix pg_upgrade will hang trying to drop in-use databases in the newly created (supposed to be) empty cluster.