### PR TITLE
Add PostgreSQL 18 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update \
     libedit-dev \
     libkrb5-dev \
     liblz4-dev \
+    libnuma-dev \
     libncurses6 \
     libpam-dev \
     libreadline-dev \

--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ BUILD_ARGS_pg14 = --build-arg PGVERSION=14 --build-arg CITUSTAG=v12.1.5
 BUILD_ARGS_pg15 = --build-arg PGVERSION=15 --build-arg CITUSTAG=v12.1.5
 BUILD_ARGS_pg16 = --build-arg PGVERSION=16 --build-arg CITUSTAG=$(CITUSTAG)
 BUILD_ARGS_pg17 = --build-arg PGVERSION=17 --build-arg CITUSTAG=$(CITUSTAG)
-BUILD_ARGS_pg18 = --build-arg PGVERSION=18 --build-arg CITUSTAG=$(CITUSTAG)
+BUILD_ARGS_pg18 = --build-arg PGVERSION=18 --build-arg CITUSTAG=803f0ac
 
 # DOCKER BUILDS
 

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -1524,7 +1524,7 @@ keeper_cli_print_version(int argc, char **argv)
 				"pg_autoctl extension version %s\n",
 				PG_AUTOCTL_EXTENSION_VERSION);
 		fformat(stdout, "compiled with %s\n", PG_VERSION_STR);
-		fformat(stdout, "compatible with Postgres 13, 14, 15, 16 and 17\n");
+		fformat(stdout, "compatible with Postgres 13, 14, 15, 16, 17 and 18\n");
 	}
 
 	exit(0);


### PR DESCRIPTION
## Summary
- Add PostgreSQL 18 to the compatibility version string in `pg_autoctl --version`
- Enable PG18 Docker builds using Citus commit `803f0ac` from `release-14.0` branch
- Add `libnuma-dev` dependency required by PostgreSQL 18

## Test plan
- [x] Single standby tests pass (88 tests)
- [x] Multi-standby tests pass (101 tests)
- [x] `pg_autoctl --version` shows "compatible with Postgres 13, 14, 15, 16, 17 and 18"

```
$ ./src/bin/pg_autoctl/pg_autoctl --version
pg_autoctl version ...
pg_autoctl extension version 2.2
compiled with PostgreSQL 18.1
compatible with Postgres 13, 14, 15, 16, 17 and 18
```

🤖 Generated with [Claude Code](https://claude.ai/code)