### PR TITLE
Add PostgreSQL 18 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update \
     libedit-dev \
     libkrb5-dev \
     liblz4-dev \
+    libnuma-dev \
     libncurses6 \
     libpam-dev \
     libreadline-dev \

--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ BUILD_ARGS_pg14 = --build-arg PGVERSION=14 --build-arg CITUSTAG=v12.1.5
 BUILD_ARGS_pg15 = --build-arg PGVERSION=15 --build-arg CITUSTAG=v12.1.5
 BUILD_ARGS_pg16 = --build-arg PGVERSION=16 --build-arg CITUSTAG=$(CITUSTAG)
 BUILD_ARGS_pg17 = --build-arg PGVERSION=17 --build-arg CITUSTAG=$(CITUSTAG)
-BUILD_ARGS_pg18 = --build-arg PGVERSION=18 --build-arg CITUSTAG=$(CITUSTAG)
+BUILD_ARGS_pg18 = --build-arg PGVERSION=18 --build-arg CITUSTAG=803f0ac
 
 # DOCKER BUILDS
 

--- a/src/bin/pg_autoctl/cli_common.c
+++ b/src/bin/pg_autoctl/cli_common.c
@@ -1524,7 +1524,7 @@ keeper_cli_print_version(int argc, char **argv)
 				"pg_autoctl extension version %s\n",
 				PG_AUTOCTL_EXTENSION_VERSION);
 		fformat(stdout, "compiled with %s\n", PG_VERSION_STR);
-		fformat(stdout, "compatible with Postgres 13, 14, 15, 16 and 17\n");
+		fformat(stdout, "compatible with Postgres 13, 14, 15, 16, 17 and 18\n");
 	}
 
 	exit(0);

--- a/src/bin/pg_autoctl/cli_do_tmux_compose.c
+++ b/src/bin/pg_autoctl/cli_do_tmux_compose.c
@@ -371,12 +371,13 @@ tmux_compose_docker_build(TmuxOptions *options)
 	}
 
 	/* prepare Postgres/Citus compatibility matrix */
-	char *pgCitusMatrix[18] = { 0 };
+	char *pgCitusMatrix[19] = { 0 };
 	pgCitusMatrix[13] = "v10.2.9";
 	pgCitusMatrix[14] = "v12.1.5";
 	pgCitusMatrix[15] = "v12.1.5";
 	pgCitusMatrix[16] = "v13.0.1";
 	pgCitusMatrix[17] = "v13.0.1";
+	pgCitusMatrix[18] = "803f0ac";
 
 	int pgVersionNum;
 	char *citustag = NULL;
@@ -387,7 +388,7 @@ tmux_compose_docker_build(TmuxOptions *options)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	if (pgVersionNum > 12 && pgVersionNum < 18)
+	if (pgVersionNum > 12 && pgVersionNum < 19)
 	{
 		citustag = pgCitusMatrix[pgVersionNum];
 	}


### PR DESCRIPTION
Builds on #1111 and adds one missing PG18 path: `pg_autoctl do tmux compose` still rejected `PGVERSION=18` because its local Postgres/Citus compatibility matrix stopped at 17.

Changes:
- keep the existing PG18 Docker and version-string updates from #1111
- add PG18 to the tmux-compose Citus matrix using the same Citus commit (`803f0ac`)
- allow `PGVERSION=18` in the tmux-compose range check

I could not retrieve the old Actions job logs for #1111 because GitHub returned HTTP 410 for the expired job logs, but the failed PG18 check annotations still point at the workflow commands exiting non-zero.