### PR TITLE
ci: split build and test into separate jobs, upgrade actions to Node 24

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     container: citus/stylechecker:no-py
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7.0.0
 
       - name: Set safe directory for git
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -28,9 +28,38 @@ jobs:
       - name: Check banned functions
         run: ci/banned.h.sh
 
-  run_tests:
-    name: Run test
+  build_images:
+    name: Build test image (PG${{ matrix.PGVERSION }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        PGVERSION:
+          - 14
+          - 15
+          - 16
+          - 17
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Build Docker test image
+        run: PGVERSION=${{ matrix.PGVERSION }} make build-test-image
+
+      - name: Save Docker image to archive
+        run: PGVERSION=${{ matrix.PGVERSION }} make save-test-image
+
+      - name: Upload image archive
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: pg-test-image-${{ matrix.PGVERSION }}
+          path: pg_auto_failover_test-pg${{ matrix.PGVERSION }}.tar.zst
+          retention-days: 1
+
+  run_tests:
+    name: Run test (${{ matrix.PGVERSION }}, ${{ matrix.TEST }})
+    runs-on: ubuntu-latest
+    needs: build_images
     strategy:
       fail-fast: false
       matrix:
@@ -50,7 +79,15 @@ jobs:
             TEST: tablespaces
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7.0.0
+
+      - name: Download image archive
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: pg-test-image-${{ matrix.PGVERSION }}
+
+      - name: Load Docker test image
+        run: PGVERSION=${{ matrix.PGVERSION }} make load-test-image
 
       - name: Set environment variables
         run: |
@@ -58,9 +95,6 @@ jobs:
           echo "TEST=${{ matrix.TEST }}" >> $GITHUB_ENV
           echo "TRAVIS_BUILD_DIR=$(pwd)" >> $GITHUB_ENV
 
-      - name: Build Docker Test Image
-        run: make build-test-image
-
       - name: Run Test
         timeout-minutes: 15
-        run: make ci-test
+        run: make run-test-prebuilt

--- a/Makefile
+++ b/Makefile
@@ -350,16 +350,20 @@ run-test: build-test-pg$(PGVERSION)
 		make -C /usr/src/pg_auto_failover test	\
 		PGVERSION=$(PGVERSION) TEST='${TEST}'
 
-# make run-test-prebuilt; like run-test but skips the build step.
+# make run-test-prebuilt; like ci-test but skips the Docker build step.
 # Used in CI after images have been built and loaded by a prior job.
 .PHONY: run-test-prebuilt
 run-test-prebuilt:
+ifeq ($(TEST),tablespaces)
+	$(MAKE) -C tests/tablespaces run-test
+else
 	docker run					                \
 		--name $(TEST_CONTAINER_NAME)		    \
 		$(DOCKER_RUN_OPTS)			            \
 		$(TEST_CONTAINER_NAME):pg$(PGVERSION)   \
 		make -C /usr/src/pg_auto_failover test	\
 		PGVERSION=$(PGVERSION) TEST='${TEST}'
+endif
 
 # make save-test-image; compresses the test image to a .tar.zst archive.
 # Used in CI to pass the built image to downstream test jobs as an artifact.

--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,31 @@ run-test: build-test-pg$(PGVERSION)
 		make -C /usr/src/pg_auto_failover test	\
 		PGVERSION=$(PGVERSION) TEST='${TEST}'
 
+# make run-test-prebuilt; like run-test but skips the build step.
+# Used in CI after images have been built and loaded by a prior job.
+.PHONY: run-test-prebuilt
+run-test-prebuilt:
+	docker run					                \
+		--name $(TEST_CONTAINER_NAME)		    \
+		$(DOCKER_RUN_OPTS)			            \
+		$(TEST_CONTAINER_NAME):pg$(PGVERSION)   \
+		make -C /usr/src/pg_auto_failover test	\
+		PGVERSION=$(PGVERSION) TEST='${TEST}'
+
+# make save-test-image; compresses the test image to a .tar.zst archive.
+# Used in CI to pass the built image to downstream test jobs as an artifact.
+.PHONY: save-test-image
+save-test-image:
+	docker save $(TEST_CONTAINER_NAME):pg$(PGVERSION) \
+	  | zstd -T0 -3 > $(TEST_CONTAINER_NAME)-pg$(PGVERSION).tar.zst
+
+# make load-test-image; decompresses and loads a .tar.zst image archive.
+# Used in CI test jobs that download the image from a prior build job.
+.PHONY: load-test-image
+load-test-image:
+	zstd -d --stdout $(TEST_CONTAINER_NAME)-pg$(PGVERSION).tar.zst \
+	  | docker load
+
 #
 # BE INTERACTIVE
 #


### PR DESCRIPTION
Previously each of the 21 test matrix cells built its own Docker image from scratch — 21 redundant builds per CI run, each taking ~2 minutes of compile time before a single test ran.

## Changes

**Workflow restructure:**
- `build_images` — 4 jobs (one per PG version), builds the test image once and uploads it as a 1-day artifact compressed with zstd
- `run_tests` — 21 jobs (same matrix as before), downloads the pre-built image and runs tests with `make run-test-prebuilt`

This cuts Docker builds from 21 to 4 per run.

**Actions upgrade:**
- `actions/checkout@v4.2.2` → `v7.0.0` (Node 24)
- `actions/upload-artifact@v7.0.1` (Node 24)
- `actions/download-artifact@v8.0.1` (Node 24)

Fixes the runner deprecation warning: _"Node.js 20 is deprecated … actions/checkout@v4.2.2"_

**New Makefile targets:**
```
make save-test-image   # docker save | zstd → pg_auto_failover_test-pg$(PGVERSION).tar.zst
make load-test-image   # zstd decompress | docker load
make run-test-prebuilt # run tests against a pre-loaded image (no build step)
```

## Tested locally

- `make save-test-image` + `make load-test-image` round-trip confirmed on PG17
- `make run-test-prebuilt PGVERSION=17 TEST=monitor` — 17/18 tests pass (1 pre-existing pyroute2 asyncio flakiness in `test_replace_monitor`, unrelated to this change)