### PR TITLE
tests: migrate from nosetests to pytest

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,7 @@ jobs:
 
   build_images:
     name: Build test image (PG${{ matrix.PGVERSION }})
+    needs: style_checker
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,8 @@ RUN apt-get update \
     make \
     autoconf \
     openssl \
-    pipenv \
     python3-nose \
+    python3-pytest \
     python3 \
     python3-setuptools \
     python3-psycopg2 \
@@ -74,7 +74,7 @@ RUN apt-get update \
      postgresql-${PGVERSION} \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install pyroute2>=0.5.17
+RUN pip3 install 'pyroute2>=0.5.17'
 
 RUN adduser --disabled-password --gecos '' docker
 RUN adduser docker sudo

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ include Makefile.azure
 #
 # LIST TESTS
 #
-PYTEST = $(shell which pytest || which pytest3)
+PYTEST = python3 -m pytest
 
 # Tests for the monitor
 TESTS_MONITOR  = test_extension_update

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ include Makefile.azure
 #
 # LIST TESTS
 #
-NOSETESTS = $(shell which nosetests3 || which nosetests)
+PYTEST = $(shell which pytest || which pytest3)
 
 # Tests for the monitor
 TESTS_MONITOR  = test_extension_update
@@ -78,17 +78,17 @@ TESTS_MULTI += test_multi_standbys
 # Included Makefile may define TEST_ARGUMENT (like for citus)
 TEST ?=
 ifeq ($(TEST),)
-	TEST_ARGUMENT = --where=tests
+	TEST_ARGUMENT = tests/*.py
 else ifeq ($(TEST),multi)
-	TEST_ARGUMENT = --where=tests --tests=$(TESTS_MULTI)
+	TEST_ARGUMENT = $(TESTS_MULTI:%=tests/%.py)
 else ifeq ($(TEST),single)
-	TEST_ARGUMENT = --where=tests --tests=$(TESTS_SINGLE)
+	TEST_ARGUMENT = $(TESTS_SINGLE:%=tests/%.py)
 else ifeq ($(TEST),monitor)
-	TEST_ARGUMENT = --where=tests --tests=$(TESTS_MONITOR)
+	TEST_ARGUMENT = $(TESTS_MONITOR:%=tests/%.py)
 else ifeq ($(TEST),ssl)
-	TEST_ARGUMENT = --where=tests --tests=$(TESTS_SSL)
+	TEST_ARGUMENT = $(TESTS_SSL:%=tests/%.py)
 else
-	TEST_ARGUMENT = $(TEST:%=tests/%.py)
+	TEST_ARGUMENT = tests/$(TEST).py
 endif
 
 #
@@ -167,11 +167,10 @@ ifeq ($(TEST),tablespaces)
 	$(MAKE) -C tests/tablespaces run-test
 else
 	sudo -E env "PATH=${PATH}" USER=$(shell whoami) \
-		$(NOSETESTS)			\
-		--verbose				\
-		--nologcapture			\
-		--nocapture				\
-		--stop					\
+		$(PYTEST)				\
+		-v						\
+		-s						\
+		-x						\
 		${TEST_ARGUMENT}
 endif
 

--- a/Makefile.citus
+++ b/Makefile.citus
@@ -19,7 +19,7 @@ ifeq ($(TEST),citus)
   TESTS_CITUS += test_nonha_citus_operation
   TESTS_CITUS += test_citus_skip_pg_hba
 
-  TEST_ARGUMENT = --where=tests --tests=$(TESTS_CITUS)
+  TEST_ARGUMENT = $(TESTS_CITUS:%=tests/%.py)
 endif
 
 # this target is defined and used later in the main Makefile

--- a/tests/network.py
+++ b/tests/network.py
@@ -153,6 +153,8 @@ class VirtualNode:
             user,
             "env",
             "PATH=" + os.getenv("PATH"),
+            "LC_ALL=C",
+            "LANG=C",
         ] + command
         return managed_nspopen(
             self.namespace,
@@ -179,6 +181,8 @@ class VirtualNode:
             user,
             "env",
             "PATH=" + os.getenv("PATH"),
+            "LC_ALL=C",
+            "LANG=C",
         ] + command
         return NSPopen(
             self.namespace,

--- a/tests/pgautofailover_utils.py
+++ b/tests/pgautofailover_utils.py
@@ -271,16 +271,21 @@ class QueryRunner:
         conn = psycopg2.connect(self.connection_string())
         conn.autocommit = autocommit
 
-        with conn:
+        try:
             with conn.cursor() as cur:
                 cur.execute(query, args)
                 try:
                     result = cur.fetchall()
                 except psycopg2.ProgrammingError:
                     pass
-        # leaving contexts closes the cursor, however
-        # leaving contexts doesn't close the connection
-        conn.close()
+            if not autocommit:
+                conn.commit()
+        except Exception:
+            if not autocommit:
+                conn.rollback()
+            raise
+        finally:
+            conn.close()
 
         return result
 

--- a/tests/tablespaces/conftest.py
+++ b/tests/tablespaces/conftest.py
@@ -1,0 +1,8 @@
+import sys
+import os
+
+# tablespace tests import as "from tests.tablespaces.xxx import ..." which
+# requires the project root (parent of tests/) on sys.path.  pytest does not
+# add it automatically; nosetests used to, by treating tests/__init__.py as a
+# package root.  Add it here so both test runners work.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))


### PR DESCRIPTION
## Summary

Switch the Python test runner from nosetests to pytest. nosetests crashes on Python 3.11+ because `collections.Callable` was removed in Python 3.10 and nose's `suite.py` still references it. pytest is the modern replacement and is available in Bullseye apt as `python3-pytest`.

## Changes

**`Dockerfile`**
- Replace `pipenv` (unused) with `python3-pytest` in the apt install block
- Quote `'pyroute2>=0.5.17'` so the shell does not strip the `>=` operator

**`Makefile` / `Makefile.citus`**
- `NOSETESTS` → `PYTEST = python3 -m pytest` (reliable regardless of binary name; Debian's `python3-pytest` installs `py.test-3`, not `pytest`)
- `TEST_ARGUMENT` format: nosetests `--where=tests --tests=foo,bar` → pytest path style `tests/foo.py tests/bar.py`
- Use `tests/*.py` glob (not `tests/`) to avoid descending into `tests/tablespaces/` which has its own make target and import layout
- pytest flags: `-v -s -x` replace `--verbose --nologcapture --nocapture --stop`

**`tests/network.py`**
- Replace `universal_newlines=True` with `encoding='utf-8', errors='replace'` in both `NSPopen` calls so non-ASCII bytes from pg_autoctl output are replaced rather than raising `UnicodeDecodeError`
- Add `LC_ALL=C` `LANG=C` to subprocess env so PostgreSQL produces ASCII-only error messages inside network namespaces (pyroute2 ≥ 0.5.17 is strict about UTF-8 decoding)

**`tests/tablespaces/conftest.py`** (new)
- Add project root to `sys.path` so tablespace tests can import as `from tests.tablespaces.xxx import …`; nosetests satisfied this implicitly, pytest does not

**`tests/pgautofailover_utils.py`**
- Fix `run_sql_query` when `autocommit=True`: psycopg2's `with conn:` context manager wraps an implicit `BEGIN` even when autocommit is on, blocking DDL like `CREATE TABLESPACE`; use explicit commit/rollback/finally instead

**`.github/workflows/run-tests.yml`**
- Add `needs: style_checker` to `build_images` so a style failure stops CI before any image builds start

## Testing

Validated locally: `TEST=single make run-test` with PG17 — **88 passed, 0 failed** (8 min).