### PR TITLE
Fix buffer overflow in parseTimeLineHistory when timeline > 1024

### DIFF
--- a/src/bin/common/pgsql.c
+++ b/src/bin/common/pgsql.c
@@ -3238,6 +3238,9 @@ parseTimeLineHistory(const char *filename, const char *content,
 			return false;
 		}
 
+		memset(newHistory + system->timelines.capacity,
+			   0,
+			   (cap - system->timelines.capacity) * sizeof(TimeLineHistoryEntry));
 		system->timelines.history = newHistory;
 		system->timelines.capacity = cap;
 	}

--- a/src/bin/common/pgsql.c
+++ b/src/bin/common/pgsql.c
@@ -3190,8 +3190,59 @@ parseTimeLineHistory(const char *filename, const char *content,
 
 	system->timelines.count = 0;
 
-	TimeLineHistoryEntry *entry =
-		&(system->timelines.history[system->timelines.count]);
+	/*
+	 * Ensure the history buffer exists and has room for at least lineCount + 1
+	 * entries (all parsed lines plus the tip entry written after the loop).
+	 * We reuse the buffer across calls; realloc only when capacity is tight.
+	 */
+	int needed = lineCount + 1;
+
+	if (system->timelines.history == NULL)
+	{
+		int cap = PG_AUTOCTL_TIMELINES_INITIAL_CAPACITY;
+
+		while (cap < needed)
+		{
+			cap *= 2;
+		}
+
+		system->timelines.history =
+			(TimeLineHistoryEntry *) calloc(cap, sizeof(TimeLineHistoryEntry));
+
+		if (system->timelines.history == NULL)
+		{
+			log_error(ALLOCATION_FAILED_ERROR);
+			free(historyLines);
+			return false;
+		}
+
+		system->timelines.capacity = cap;
+	}
+	else if (system->timelines.capacity < needed)
+	{
+		int cap = system->timelines.capacity;
+
+		while (cap < needed)
+		{
+			cap *= 2;
+		}
+
+		TimeLineHistoryEntry *newHistory =
+			(TimeLineHistoryEntry *) realloc(system->timelines.history,
+											 cap * sizeof(TimeLineHistoryEntry));
+
+		if (newHistory == NULL)
+		{
+			log_error(ALLOCATION_FAILED_ERROR);
+			free(historyLines);
+			return false;
+		}
+
+		system->timelines.history = newHistory;
+		system->timelines.capacity = cap;
+	}
+
+	TimeLineHistoryEntry *entry = &(system->timelines.history[0]);
 
 	for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
 	{
@@ -3271,7 +3322,7 @@ parseTimeLineHistory(const char *filename, const char *content,
 
 	/*
 	 * Create one more entry for the "tip" of the timeline, which has no entry
-	 * in the history file.
+	 * in the history file. Capacity was pre-checked above to include this slot.
 	 */
 	entry->tli = system->timeline;
 	entry->begin = prevend;

--- a/src/bin/common/pgsql.h
+++ b/src/bin/common/pgsql.h
@@ -193,7 +193,7 @@ typedef struct NodeAddressArray
 #define InvalidXLogRecPtr 0
 #define XLogRecPtrIsInvalid(r) ((r) == InvalidXLogRecPtr)
 
-#define PG_AUTOCTL_MAX_TIMELINES 1024
+#define PG_AUTOCTL_TIMELINES_INITIAL_CAPACITY 16
 
 typedef struct TimeLineHistoryEntry
 {
@@ -203,10 +203,19 @@ typedef struct TimeLineHistoryEntry
 } TimeLineHistoryEntry;
 
 
+/*
+ * TimeLineHistory holds a dynamically-allocated array of timeline history
+ * entries. The history pointer starts as NULL and is allocated on first use
+ * inside parseTimeLineHistory(); subsequent calls reuse the same buffer,
+ * growing it with realloc() when needed. No explicit free is required because
+ * this struct is embedded in long-lived per-process structs (LocalPostgresServer
+ * → ReplicationSource → IdentifySystem) that live for the process lifetime.
+ */
 typedef struct TimeLineHistory
 {
 	int count;
-	TimeLineHistoryEntry history[PG_AUTOCTL_MAX_TIMELINES];
+	int capacity;
+	TimeLineHistoryEntry *history;
 } TimeLineHistory;
 
 


### PR DESCRIPTION
## Problem

When a pg_auto_failover cluster has undergone more than ~1024 failovers, its current PostgreSQL timeline number exceeds 1024. At that point the `TIMELINE_HISTORY` replication command returns more than 1024 lines, overflowing the fixed-size `history[PG_AUTOCTL_MAX_TIMELINES]` array inside `TimeLineHistory`.

`parseTimeLineHistory` writes a "tip" entry unconditionally after the loop at `history[count]`, where `count` has just reached 1024 — one slot past the end of the array. Each additional timeline pushes that write further into memory. The array is the last field of `IdentifySystem`, which is the last field of `ReplicationSource`, which is embedded in `LocalPostgresServer`. The overflow therefore corrupts the fields that immediately follow in that struct: `pgIsRunning`, `pgsrSyncState`, `currentLSN`, `pgFirstStartFailureTs`, `pgStartRetries`, and `pgKind`.

The keeper then logs:

```
nodeKindToString: unknown node kind XX
```

and behaves incorrectly because `pgKind` now holds garbage bytes from the overwritten LSN data.

This bug is in the **keeper** (client code, `src/bin/common/pgsql.c`). The monitor is not involved.

## Fix

Replace the fixed-size array in `TimeLineHistory` with a heap-allocated pointer:

```c
typedef struct TimeLineHistory
{
    int count;
    int capacity;
    TimeLineHistoryEntry *history;   /* NULL until first parseTimeLineHistory() call */
} TimeLineHistory;
```

`parseTimeLineHistory()` allocates the buffer on first use and grows it with `realloc()` (doubling strategy) when needed. Because `ReplicationSource` is embedded in the long-lived `Keeper` struct, the buffer is reused across repeated `pgctl_identify_system()` calls and freed by the OS on process exit — no explicit cleanup path is needed.

All consumer sites (`cli_do_misc.c`, `pgsql.c:3041`) already use `history[index]` pointer-subscript syntax, which is syntactically identical whether `history` is a fixed array or a heap pointer — no changes to those callers are required.

Closes: #1107