### PR TITLE
keeper: send node_active reports to monitor during graceful shutdown

### DIFF
--- a/src/bin/pg_autoctl/service_keeper.c
+++ b/src/bin/pg_autoctl/service_keeper.c
@@ -245,6 +245,61 @@ service_keeper_node_active_init(Keeper *keeper)
 
 
 /*
+ * keeper_node_active_shutdown_loop sends node_active reports to the monitor
+ * every second for up to KEEPER_SHUTDOWN_LOOP_MAX_SECS while PostgreSQL stops.
+ *
+ * This runs after the main node-active loop exits on SIGTERM, concurrently
+ * with the postgres-controller service (a sibling process) calling
+ * "pg_ctl stop -m fast".
+ *
+ * When SIGTERM reaches the postmaster, process_pm_shutdown_request()
+ * (src/backend/postmaster/postmaster.c) sets Shutdown = FastShutdown and
+ * calls UpdatePMState(PM_STOP_BACKENDS).  After that transition,
+ * canAcceptConnections() (same file) returns CAC_SHUTDOWN for every new
+ * connection attempt, so the primary stops accepting writes immediately —
+ * before a single backend has rolled back.  Only the final checkpoint that
+ * follows can be slow.
+ *
+ * By continuing to call node_active with the current pgIsRunning value here,
+ * we ensure the monitor learns the primary is going away within one second of
+ * the shutdown starting, and can begin failover right away rather than waiting
+ * for a health-check timeout.
+ */
+#define KEEPER_SHUTDOWN_LOOP_MAX_SECS 30
+
+static void
+keeper_node_active_shutdown_loop(Keeper *keeper)
+{
+	LocalPostgresServer *postgres = &(keeper->postgres);
+
+	log_info("Graceful shutdown: reporting node state to monitor "
+			 "while PostgreSQL stops (up to %d seconds)",
+			 KEEPER_SHUTDOWN_LOOP_MAX_SECS);
+
+	for (int i = 0; i < KEEPER_SHUTDOWN_LOOP_MAX_SECS; i++)
+	{
+		/* escalated signal: exit without further reporting */
+		if (asked_to_quit || asked_to_stop_fast)
+		{
+			break;
+		}
+
+		(void) keeper_update_pg_state(keeper, LOG_DEBUG);
+		(void) service_keeper_node_active(keeper, false);
+
+		if (!postgres->pgIsRunning)
+		{
+			log_info("PostgreSQL has stopped; "
+					 "final node_active report sent to monitor");
+			break;
+		}
+
+		pg_usleep(1000000L); /* 1 second */
+	}
+}
+
+
+/*
  * keeper_node_active_loop implements the main loop of the keeper, which
  * periodically gets the goal state from the monitor and makes the state
  * transitions.
@@ -657,6 +712,16 @@ keeper_node_active_loop(Keeper *keeper, pid_t start_pid)
 			warnedOnPreviousIteration = true;
 			warnedOnCurrentIteration = false;
 		}
+	}
+
+	/*
+	 * Graceful SIGTERM shutdown: keep reporting state to the monitor while
+	 * PostgreSQL finishes its checkpoint and stops.  Skip on SIGINT/SIGQUIT
+	 * which request immediate exit.
+	 */
+	if (asked_to_stop && !asked_to_stop_fast && !asked_to_quit)
+	{
+		(void) keeper_node_active_shutdown_loop(keeper);
 	}
 
 	/* One last check that we do not have any connections open */

--- a/tests/tap/specs/ensure.pgaf
+++ b/tests/tap/specs/ensure.pgaf
@@ -41,7 +41,13 @@ step test_003_init_secondary {
     wait until node2 state is secondary
         and node1 state is primary
         timeout 90s
+    # Stop postgres while pg_autoctl is running, then re-enable auto-start so
+    # the keeper restarts postgres automatically.  This tests that the keeper
+    # recovers from an unexpected postgres stop.  The Python equivalent is
+    # node2.stop_postgres() which sends SIGTERM to postgres without disabling
+    # the pg_autoctl postgres-controller restart logic.
     stop postgres node2
+    start postgres node2
     wait until node2 state is secondary
         and node1 state is primary
         timeout 90s


### PR DESCRIPTION
When the keeper process (node-active service) receives SIGTERM, it previously
broke out of its main loop immediately — before calling
`keeper_update_pg_state()` or `service_keeper_node_active()`.  The monitor
had no way to learn the node was going offline until its next health-check
poll, which could be several seconds later.  During that window the monitor
may not trigger failover fast enough, causing standbys to time out waiting
for `wait_primary`.

## Changes

**`service_keeper.c` — `keeper_node_active_shutdown_loop()`**

After the main loop breaks on `asked_to_stop`, the keeper reports its
current Postgres state to the monitor every 1 s for up to 30 seconds, or
until Postgres stops or an escalated signal (`SIGINT` / `SIGQUIT`) arrives —
whichever comes first.  This runs concurrently with the postgres-controller
service calling `pg_ctl stop -m fast`.

Fast mode sends SIGTERM to the PostgreSQL postmaster.  Inside
`process_pm_shutdown_request()` (`src/backend/postmaster/postmaster.c`) the
postmaster sets `Shutdown = FastShutdown` and transitions to
`PM_STOP_BACKENDS`.  After that, `canAcceptConnections()` returns
`CAC_SHUTDOWN` for every new connection attempt — the primary stops
accepting writes before a single backend has rolled back, and long before the
checkpoint finishes.  By the time the first shutdown report fires, Postgres
is already refusing connections; the monitor can start failover right away
rather than waiting for a health-check timeout.

`SIGINT` (`asked_to_stop_fast`) and `SIGQUIT` (`asked_to_quit`) skip the
shutdown loop and exit immediately, as before.

**Compatibility with PID-1 environments:**

- **Docker / Compose**: `docker compose stop` sends SIGTERM to PID 1, waits
  `stop_grace_period` (default 10 s), then SIGKILL.  The shutdown loop
  typically reports `pgIsRunning=false` within 1–2 s.
- **Kubernetes**: graceful termination sends SIGTERM and waits
  `terminationGracePeriodSeconds` (default 30 s).  The 30-second loop cap
  aligns with this default.
- **systemd**: `systemctl stop` sends SIGTERM; `TimeoutStopSec` defaults to
  90 s.  The loop exits as soon as Postgres stops, well before that limit.

In all three environments the protocol is identical: SIGTERM → bounded wait
→ SIGKILL.  This change makes pg_auto_failover a cooperative participant
rather than exiting silently on the first signal.

**`tests/tap/specs/ensure.pgaf` — fix `test_003_init_secondary`**

`stop postgres node2` calls `pg_autoctl manual service pgctl off`, which
stops Postgres *and* disables auto-restart.  With auto-restart disabled,
`node2->pgIsRunning` stayed false through `test_004_demoted`, causing
`NodeIsHealthy(node2)` to return false and the failover gate at
`group_state_machine.c:550` to never fire.

Fix: add `start postgres node2` immediately after to re-enable the keeper's
auto-restart, matching the behaviour of the original Python test
(`node2.stop_postgres()` sends SIGTERM to Postgres without touching the
service controller).