### PR TITLE
ci: dump regression.diffs on installcheck failure in the build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,14 @@ RUN if [ -d src/bin/pgaftest ]; then \
     fi
 
 RUN make -s clean && make -s install -j$(nproc) BINDIR=/usr/local/bin
+# On failure, dump every *.diffs file: the container (and with it
+# src/monitor/regression.diffs) is discarded once the build fails, so this
+# is the only way a CI log ends up showing what actually differed instead
+# of just the postmaster log tail.
 RUN pg_virtualenv -v ${PGVERSION} \
       -o "shared_preload_libraries=pgautofailover" \
-      make -C src/monitor/ installcheck
+      make -C src/monitor/ installcheck || \
+      (find src/monitor -name '*.diffs' -exec cat {} +; exit 1)
 
 # ---------------------------------------------------------------------------
 # test — old Python test runner (kept for compatibility; new tests use pgaftest)


### PR DESCRIPTION
## Problem

When `RUN pg_virtualenv ... make -C src/monitor/ installcheck` fails during the Docker `build` stage, the container running it is discarded on failure — so `src/monitor/regression.diffs`, the one file that actually shows what differed between expected and actual output, never makes it into the CI log. All CI (and anyone reading it later) gets is the postmaster log tail, which is often noise from unrelated concurrently-registered test fixtures and rarely points at the real cause.

This came up directly while diagnosing recent regress failures on #1149/#1151: pinning down the actual cause required reproducing the build locally and temporarily hacking the Dockerfile to `cat` the diffs file. That workaround is worth keeping permanently instead of redoing it by hand every time.

## Fix

```dockerfile
RUN pg_virtualenv -v ${PGVERSION} \
      -o "shared_preload_libraries=pgautofailover" \
      make -C src/monitor/ installcheck || \
      (find src/monitor -name '*.diffs' -exec cat {} +; exit 1)
```

On failure, find and `cat` every `*.diffs` file under `src/monitor/` (covers both the `REGRESS` and `ISOLATION` suites, wherever `pg_regress`/`pg_isolation_regress` happen to write them), then re-raise the original failure so the build still fails exactly as before.

## Verified

`make build-pg18`:
- Success path (current `main`) is unaffected — clean build, no output changes.
- Failure path: deliberately corrupted `expected/create_extension.out`'s output locally, rebuilt, confirmed the diff appears directly in the build log (both in the final failure dump and in buildx's error-context excerpt), then reverted the deliberate corruption.
