### PR TITLE
ci: fix dpkg-query format-string escaping in check-versions.yml

### DIFF
--- a/.github/workflows/check-versions.yml
+++ b/.github/workflows/check-versions.yml
@@ -124,7 +124,7 @@ jobs:
             apt-get update -qq 2>/dev/null
             CHANGED=false
             for pg in 14 15 16 17; do
-              installed=$(dpkg-query -W -f="\\${Version}" postgresql-${pg} 2>/dev/null || echo "")
+              installed=$(dpkg-query -W -f="\${Version}" postgresql-${pg} 2>/dev/null || echo "")
               available=$(apt-cache show postgresql-${pg} 2>/dev/null \
                 | awk "/^Version:/{print \$2; exit}")
               if [ -z "$installed" ] && [ -z "$available" ]; then


### PR DESCRIPTION
## Problem

The weekly "Check PGDG + Citus versions" workflow (`check-versions.yml`) has been failing on every scheduled run, for every supported PG version (14–17), regardless of whether PGDG actually released anything new:

```
PGDG PG14: installed=, available=14.23-1.pgdg12+1 → STALE
PGDG PG15: installed=, available=15.18-1.pgdg12+1 → STALE
PGDG PG16: installed=, available=16.14-1.pgdg12+1 → STALE
PGDG PG17: installed=, available=17.10-1.pgdg12+1 → STALE
```

This is a false negative in the check script itself, not a real version drift — `installed` is always empty, for every version, every run.

## Root cause

```bash
installed=$(dpkg-query -W -f="\\${Version}" postgresql-${pg} 2>/dev/null || echo "")
```

This line sits inside `docker run --rm "$IMAGE" bash -c '...'`, where the *entire* inner script is single-quoted by the outer (runner) shell — so the outer shell passes `\\${Version}` through completely unchanged. Inside the container's own `bash -c`, though, this text is part of a double-quoted `-f="..."` argument: `\\` collapses to one literal backslash, and the now-unescaped `${Version}` gets parameter-expanded as a shell variable. `Version` was never set anywhere, so it silently expands to nothing. `dpkg-query` ends up invoked with a bare backslash as its format string, instead of the literal `${Version}` template it needs (that's `dpkg-query`'s own field-substitution syntax, not a shell variable) — and returns nothing.

With `installed` always empty and `available` resolving correctly one line below (via a separately, correctly, double-quoted `apt-cache`/`awk` pipeline), every PG version compares unequal and gets flagged `STALE`, forcing `pgdg_changed=true` unconditionally on every run.

## Fix

Drop one backslash: `\\${Version}` → `\${Version}`. The outer single-quoting still passes it through unchanged; the container's bash now sees `\$` inside its double-quoted string, which escapes to a literal `$`, yielding the literal string `${Version}` that `dpkg-query` expects.

## Verification

Reproduced the exact quoting locally, then built a throwaway `debian:bookworm-slim` container and installed `postgresql-17` from the real PGDG repo the same way `Dockerfile.base` does, to test both the old and fixed format strings against a real installed package:

```
old (\\${Version}): installed=[]                        <- garbage, always empty
new (\${Version}):  installed=[17.10-1.pgdg12+1]
                     available=[17.10-1.pgdg12+1]        <- correctly matches, not stale
```

No functional change to what the workflow does when a version genuinely is stale — only fixes the comparison so it stops reporting every run as stale unconditionally.