### PR TITLE
pg_autoctl: retry perform_failover on transient monitor deadlocks (#1004)

### DIFF
--- a/src/bin/pg_autoctl/cli_perform.c
+++ b/src/bin/pg_autoctl/cli_perform.c
@@ -300,31 +300,60 @@ cli_perform_failover(int argc, char **argv)
 		exit(EXIT_CODE_MONITOR);
 	}
 
-	bool performOk;
+	/*
+	 * perform_failover() on the monitor can hit a genuine but transient
+	 * Postgres deadlock racing a concurrent node_active()/health-check
+	 * write (see #1004): retry it the same way enable/disable maintenance
+	 * already do for their own monitor calls, rather than failing the
+	 * whole command on the first transient error.
+	 */
+	ConnectionRetryPolicy retryPolicy = { 0 };
 
-	if (keeperOptions.allowDataLoss)
+	(void) pgsql_set_monitor_interactive_retry_policy(&retryPolicy);
+
+	while (!pgsql_retry_policy_expired(&retryPolicy))
 	{
-		performOk = monitor_perform_failover_allow_data_loss(
-			&monitor, config.formation, config.groupId);
+		bool performOk;
+		bool mayRetry = false;
 
-		if (!performOk)
+		if (keeperOptions.allowDataLoss)
 		{
-			log_fatal("Failed to perform failover with --allow-data-loss, "
-					  "see above for details");
+			performOk = monitor_perform_failover_allow_data_loss(
+				&monitor, config.formation, config.groupId, &mayRetry);
+		}
+		else
+		{
+			performOk = monitor_perform_failover(
+				&monitor, config.formation, config.groupId, &mayRetry);
+		}
+
+		if (performOk)
+		{
+			break;
+		}
+
+		if (!mayRetry)
+		{
+			log_fatal("Failed to perform failover%s, see above for details",
+					  keeperOptions.allowDataLoss ? " with --allow-data-loss" : "");
 			exit(EXIT_CODE_MONITOR);
 		}
+
+		int sleepTimeMs = pgsql_compute_connection_retry_sleep_time(&retryPolicy);
+
+		log_warn("Failed to perform failover%s, retrying in %d ms.",
+				 keeperOptions.allowDataLoss ? " with --allow-data-loss" : "",
+				 sleepTimeMs);
+
+		/* we have milliseconds, pg_usleep() wants microseconds */
+		(void) pg_usleep(sleepTimeMs * 1000);
 	}
-	else
-	{
-		performOk = monitor_perform_failover(
-			&monitor, config.formation, config.groupId);
 
-		if (!performOk)
-		{
-			log_fatal("Failed to perform failover/switchover, "
-					  "see above for details");
-			exit(EXIT_CODE_MONITOR);
-		}
+	if (pgsql_retry_policy_expired(&retryPolicy))
+	{
+		log_fatal("Failed to perform failover/switchover, "
+				  "see above for details");
+		exit(EXIT_CODE_MONITOR);
 	}
 
 	/* process state changes notification until we have a new primary */

--- a/src/bin/pg_autoctl/demoapp.c
+++ b/src/bin/pg_autoctl/demoapp.c
@@ -440,7 +440,9 @@ demoapp_process_perform_switchover(DemoAppOptions *demoAppOptions)
 			continue;
 		}
 
-		if (!monitor_perform_failover(&monitor, formation, groupId))
+		bool mayRetry = false;
+
+		if (!monitor_perform_failover(&monitor, formation, groupId, &mayRetry))
 		{
 			log_fatal("Failed to perform failover/switchover, "
 					  "see above for details");

--- a/src/bin/pg_autoctl/monitor.c
+++ b/src/bin/pg_autoctl/monitor.c
@@ -1904,9 +1904,20 @@ monitor_get_groupId_from_name(Monitor *monitor, char *formation, char *name,
 /*
  * monitor_perform_failover calls the pgautofailover.monitor_perform_failover
  * function on the monitor.
+ *
+ * perform_failover() takes the same LockFormation()/LockNodeGroup() advisory
+ * locks every other node-mutating entry point does, so it can race a
+ * concurrent node_active()/health-check write and hit a genuine Postgres
+ * deadlock (see #1004) -- transient by nature, and already covered by
+ * monitor_retryable_error() for every other entry point that can hit it
+ * (monitor_start_maintenance, monitor_stop_maintenance,
+ * monitor_register_node, ...) except this one. *mayRetry follows that same
+ * convention: set it and return false so the caller can apply its own retry
+ * policy, exactly as for start_maintenance/stop_maintenance.
  */
 bool
-monitor_perform_failover(Monitor *monitor, char *formation, int group)
+monitor_perform_failover(Monitor *monitor, char *formation, int group,
+						 bool *mayRetry)
 {
 	PGSQL *pgsql = &monitor->pgsql;
 	const char *sql = "SELECT pgautofailover.perform_failover($1, $2)";
@@ -1914,19 +1925,34 @@ monitor_perform_failover(Monitor *monitor, char *formation, int group)
 	Oid paramTypes[2] = { TEXTOID, INT4OID };
 	const char *paramValues[2];
 	IntString groupString = intToString(group);
+	AbstractResultContext context = {
+		{ 0 }
+	};
 
 	paramValues[0] = formation;
 	paramValues[1] = groupString.strValue;
 
 	/*
-	 * pgautofailover.perform_failover() returns VOID.
+	 * pgautofailover.perform_failover() returns VOID: we only need the
+	 * context to capture the SQLSTATE on failure, there is nothing to parse
+	 * on success.
 	 */
 	if (!pgsql_execute_with_params(pgsql, sql,
 								   paramCount, paramTypes, paramValues,
-								   NULL, NULL))
+								   &context, NULL))
 	{
-		log_error("Failed to perform failover for formation %s and group %d",
-				  formation, group);
+		if (monitor_retryable_error(context.sqlstate))
+		{
+			*mayRetry = true;
+		}
+		else
+		{
+			/* when we may retry then it's up to the caller to handle errors */
+			log_error("Failed to perform failover for formation %s "
+					  "and group %d",
+					  formation, group);
+		}
+
 		return false;
 	}
 
@@ -1938,11 +1964,16 @@ monitor_perform_failover(Monitor *monitor, char *formation, int group)
  * monitor_perform_failover_allow_data_loss runs perform_failover in a
  * transaction with guard_data_loss disabled, accepting the risk of data
  * loss when quorum nodes have not reported their LSN.
+ *
+ * See monitor_perform_failover's docstring for why *mayRetry is needed here
+ * too: the underlying perform_failover() call is the same SQL function and
+ * can hit the exact same transient deadlock.
  */
 bool
 monitor_perform_failover_allow_data_loss(Monitor *monitor,
 										 char *formation,
-										 int group)
+										 int group,
+										 bool *mayRetry)
 {
 	PGSQL *pgsql = &monitor->pgsql;
 	const char *sql = "SELECT pgautofailover.perform_failover($1, $2)";
@@ -1950,6 +1981,9 @@ monitor_perform_failover_allow_data_loss(Monitor *monitor,
 	Oid paramTypes[2] = { TEXTOID, INT4OID };
 	const char *paramValues[2];
 	IntString groupString = intToString(group);
+	AbstractResultContext context = {
+		{ 0 }
+	};
 
 	paramValues[0] = formation;
 	paramValues[1] = groupString.strValue;
@@ -1970,12 +2004,21 @@ monitor_perform_failover_allow_data_loss(Monitor *monitor,
 
 	if (!pgsql_execute_with_params(pgsql, sql,
 								   paramCount, paramTypes, paramValues,
-								   NULL, NULL))
+								   &context, NULL))
 	{
-		log_error("Failed to perform failover with --allow-data-loss "
-				  "for formation %s and group %d",
-				  formation, group);
 		(void) pgsql_rollback(pgsql);
+
+		if (monitor_retryable_error(context.sqlstate))
+		{
+			*mayRetry = true;
+		}
+		else
+		{
+			log_error("Failed to perform failover with --allow-data-loss "
+					  "for formation %s and group %d",
+					  formation, group);
+		}
+
 		return false;
 	}
 

--- a/src/bin/pg_autoctl/monitor.h
+++ b/src/bin/pg_autoctl/monitor.h
@@ -187,10 +187,12 @@ bool monitor_get_groupId_from_name(Monitor *monitor,
 								   char *formation, char *name,
 								   int *groupId);
 
-bool monitor_perform_failover(Monitor *monitor, char *formation, int group);
+bool monitor_perform_failover(Monitor *monitor, char *formation, int group,
+							  bool *mayRetry);
 bool monitor_perform_failover_allow_data_loss(Monitor *monitor,
 											  char *formation,
-											  int group);
+											  int group,
+											  bool *mayRetry);
 bool monitor_perform_promotion(Monitor *monitor, char *formation, char *name);
 
 bool monitor_get_current_state(Monitor *monitor, char *formation, int group,


### PR DESCRIPTION
Fixes #1004 (reopening/re-closing with an actual fix, since the original close had no linked PR or commit).

## Background

#1004 reported `pg_autoctl perform switchover` failing outright on a monitor-side Postgres deadlock:

```
ERROR Monitor ERROR:  deadlock detected
ERROR Monitor DETAIL:  Process 18419 waits for ShareLock on transaction 3711; blocked by process 18418.
ERROR Monitor Process 18418 waits for ExclusiveLock on advisory lock [16385,1338977919,0,11]; blocked by process 18419.
ERROR Monitor CONTEXT:  while updating tuple (0,10) in relation "node"
ERROR SQL query: SELECT pgautofailover.perform_failover($1, $2)
FATAL Failed to perform failover/switchover, see above for details
```

and asked for pg_autoctl to retry transient errors like this rather than fail the whole command.

Three separate things were going on here, and I checked all three against current `main`:

1. **The deadlock's root cause** (inconsistent lock-acquisition order across different node-mutating monitor functions) is already fixed, by #1150 (`LockNodeGroupAndFetch()`/`LockNodeGroupAndFetchByName()`, unifying every node-mutating entry point onto a single, consistently-ordered lock-then-fetch helper). That PR never referenced #1004, so the issue never got closed with an explanation.

2. **The retry-policy request is not fixed.** pg_autoctl has had a retry mechanism for exactly this SQLSTATE class since 2020 (`monitor_retryable_error()` in `monitor.c`, covering `deadlock_detected`/`serialization_failure`/etc, added in #359) -- `monitor_start_maintenance`, `monitor_stop_maintenance`, and `monitor_register_node` all use it. But `monitor_perform_failover()` and `monitor_perform_failover_allow_data_loss()` -- the exact functions behind the reporter's failing command -- were never wired into it. Confirmed by reading current `main`: both just run their query once and fail hard on any error.

3. **The secondary "stuck at demote_timeout forever" symptom** the reporter also described (a production failover that left the old primary permanently parked at `demote_timeout`, requiring a manual restart) is a different mechanism entirely -- a state-machine deadlock (no legal `KeeperFSM[]` transition out of an assigned goal state), not a Postgres lock deadlock. That's already fixed too, independently: #1158 (#1025) and #1165 (#774) both root-cause and close variants of a primary landing in an unreachable goal state during failover. Not the same bug as 1/2 above, but worth noting since the reporter conflated the two symptoms in the original issue.

## Fix

- `monitor_perform_failover()` / `monitor_perform_failover_allow_data_loss()` (`monitor.c`) now take a `bool *mayRetry` out-parameter, following the exact convention already used by `monitor_start_maintenance`/`monitor_stop_maintenance`: set it and return `false` when `monitor_retryable_error()` says the failure is transient.
- `cli_perform_failover()` (`cli_perform.c`, backing both `pg_autoctl perform failover` and `perform switchover`) wraps the call in the same `ConnectionRetryPolicy` loop `enable`/`disable maintenance` already use.
- `demoapp.c`'s own call site updated for the new signature (it already retries on its own schedule via its outer loop; no behavior change there).

## Verification

- Clean build (`make -C src/bin/pg_autoctl`).
- `make docker-check` (citus_indent) and `ci/banned.h.sh` both clean.
- Full Docker run of `basic_operation.pgaf`: 27/27 pass, including `test_020_multiple_manual_failover_verify_replication_slots` which exercises `perform_failover` directly -- confirms no regression to the normal, non-deadlock path.

The deadlock itself is timing-sensitive and no longer reliably reproducible now that #1150 fixed the underlying lock-ordering bug, so this is a defense-in-depth fix for the residual case (a transient deadlock/serialization failure from some other, not-yet-identified race) rather than something with its own new regression test that manufactures the exact race.
