### PR TITLE
Make pg_autoctl show state --local read-only

### DIFF
--- a/src/bin/pg_autoctl/cli_show.c
+++ b/src/bin/pg_autoctl/cli_show.c
@@ -583,7 +583,7 @@ cli_show_local_state(void)
 				exit(EXIT_CODE_BAD_CONFIG);
 			}
 
-			if (!keeper_init(&keeper, &config))
+			if (!keeper_init_read_only(&keeper, &config))
 			{
 				/* errors have already been logged */
 				exit(EXIT_CODE_BAD_CONFIG);

--- a/src/bin/pg_autoctl/keeper.c
+++ b/src/bin/pg_autoctl/keeper.c
@@ -42,18 +42,32 @@ static void diff_nodesArray(NodeAddressArray *previousNodesArray,
 
 
 /*
- * keeper_init initializes the keeper logic according to the given keeper
- * configuration. It also reads the state file from disk. The state file
- * must be generated before calling keeper_init.
+ * keeper_init_internal initializes the keeper logic according to the given
+ * keeper configuration. It also reads the state file from disk. The state
+ * file must be generated before calling keeper_init/keeper_init_read_only.
+ *
+ * manageLocalPostgres controls whether we take over the pg_autoctl.pg
+ * status file used to talk to the Postgres controller sub-process: a
+ * read-only, one-shot command (see keeper_init_read_only, #1154) must not
+ * remove that file out from under a controller that might currently be
+ * managing this same PGDATA.
  */
-bool
-keeper_init(Keeper *keeper, KeeperConfig *config)
+static bool
+keeper_init_internal(Keeper *keeper, KeeperConfig *config,
+					 bool manageLocalPostgres)
 {
 	PostgresSetup *pgSetup = &(config->pgSetup);
 
 	keeper->config = *config;
 
-	local_postgres_init(&keeper->postgres, pgSetup);
+	if (manageLocalPostgres)
+	{
+		local_postgres_init(&keeper->postgres, pgSetup);
+	}
+	else
+	{
+		local_postgres_init_read_only(&keeper->postgres, pgSetup);
+	}
 
 	if (!config->monitorDisabled)
 	{
@@ -70,6 +84,32 @@ keeper_init(Keeper *keeper, KeeperConfig *config)
 	}
 
 	return true;
+}
+
+
+/*
+ * keeper_init initializes the keeper logic according to the given keeper
+ * configuration. It also reads the state file from disk. The state file
+ * must be generated before calling keeper_init.
+ */
+bool
+keeper_init(Keeper *keeper, KeeperConfig *config)
+{
+	return keeper_init_internal(keeper, config, true);
+}
+
+
+/*
+ * keeper_init_read_only is the same as keeper_init, without removing a
+ * pre-existing pg_autoctl.pg file: for read-only, one-shot commands such as
+ * `pg_autoctl show state --local` that must not interfere with a Postgres
+ * controller process that might currently be managing this same PGDATA
+ * (see #1154).
+ */
+bool
+keeper_init_read_only(Keeper *keeper, KeeperConfig *config)
+{
+	return keeper_init_internal(keeper, config, false);
 }
 
 

--- a/src/bin/pg_autoctl/keeper.h
+++ b/src/bin/pg_autoctl/keeper.h
@@ -44,6 +44,7 @@ typedef struct KeeperVersion
 
 
 bool keeper_init(Keeper *keeper, KeeperConfig *config);
+bool keeper_init_read_only(Keeper *keeper, KeeperConfig *config);
 bool keeper_init_fsm(Keeper *keeper);
 bool keeper_register_and_init(Keeper *keeper, NodeState initialState);
 bool keeper_register_again(Keeper *keeper);

--- a/src/bin/pg_autoctl/primary_standby.c
+++ b/src/bin/pg_autoctl/primary_standby.c
@@ -110,11 +110,19 @@ GUC citus_default_settings_13[] = {
 
 
 /*
- * local_postgres_init initializes an interface for managing a local
- * postgres server with the given setup.
+ * local_postgres_init_internal initializes an interface for managing a local
+ * postgres server with the given setup. unlinkStatusFile controls whether
+ * any stale pg_autoctl.pg file is removed: that file is the postgres
+ * controller sub-process's only signal for whether Postgres is expected to
+ * be running, so removing it is only safe when this process is actually
+ * going to take over managing Postgres. A read-only, one-shot command
+ * sharing this init path (e.g. `pg_autoctl show state --local`, see #1154)
+ * must not delete it out from under a live controller.
  */
-void
-local_postgres_init(LocalPostgresServer *postgres, PostgresSetup *pgSetup)
+static void
+local_postgres_init_internal(LocalPostgresServer *postgres,
+							 PostgresSetup *pgSetup,
+							 bool unlinkStatusFile)
 {
 	char connInfo[MAXCONNINFO];
 
@@ -130,11 +138,36 @@ local_postgres_init(LocalPostgresServer *postgres, PostgresSetup *pgSetup)
 	/* set the local instance kind from the configuration. */
 	postgres->pgKind = pgSetup->pgKind;
 
-	if (!local_postgres_set_status_path(postgres, true))
+	if (!local_postgres_set_status_path(postgres, unlinkStatusFile))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_BAD_STATE);
 	}
+}
+
+
+/*
+ * local_postgres_init initializes an interface for managing a local
+ * postgres server with the given setup.
+ */
+void
+local_postgres_init(LocalPostgresServer *postgres, PostgresSetup *pgSetup)
+{
+	local_postgres_init_internal(postgres, pgSetup, true);
+}
+
+
+/*
+ * local_postgres_init_read_only is the same as local_postgres_init, without
+ * removing a pre-existing pg_autoctl.pg file: for read-only, one-shot
+ * commands that must not interfere with a Postgres controller process that
+ * might currently be managing this same PGDATA (see #1154).
+ */
+void
+local_postgres_init_read_only(LocalPostgresServer *postgres,
+							  PostgresSetup *pgSetup)
+{
+	local_postgres_init_internal(postgres, pgSetup, false);
 }
 
 

--- a/src/bin/pg_autoctl/primary_standby.h
+++ b/src/bin/pg_autoctl/primary_standby.h
@@ -84,6 +84,8 @@ typedef struct LocalPostgresServer
 
 void local_postgres_init(LocalPostgresServer *postgres,
 						 PostgresSetup *postgresSetup);
+void local_postgres_init_read_only(LocalPostgresServer *postgres,
+								   PostgresSetup *postgresSetup);
 bool local_postgres_set_status_path(LocalPostgresServer *postgres, bool unlink);
 bool local_postgres_unlink_status_file(LocalPostgresServer *postgres);
 void local_postgres_finish(LocalPostgresServer *postgres);

--- a/tests/tap/specs/basic_operation.pgaf
+++ b/tests/tap/specs/basic_operation.pgaf
@@ -64,6 +64,17 @@ step test_003_create_t1 {
     expect { 2 }
 }
 
+step test_003_show_state_local_is_read_only {
+    # `pg_autoctl show state --local` must never delete pg_autoctl.pg, the
+    # postgres controller's only signal for whether Postgres is expected to
+    # be running (see #1154): plant a stand-in for that file and confirm the
+    # command leaves it alone.
+    exec node1  bash -c 'touch "${XDG_RUNTIME_DIR:-/tmp}/pg_autoctl${PGDATA}/pg_autoctl.pg"'
+    exec node1  pg_autoctl show state --local
+    exec node1  bash -c 'test -f "${XDG_RUNTIME_DIR:-/tmp}/pg_autoctl${PGDATA}/pg_autoctl.pg"'
+    exec node1  bash -c 'rm -f "${XDG_RUNTIME_DIR:-/tmp}/pg_autoctl${PGDATA}/pg_autoctl.pg"'
+}
+
 #
 # test_004: verify synchronous_standby_names and replication slots
 #           after secondary joins.  Both nodes must have a physical slot


### PR DESCRIPTION
Fixes #1154.

## Background

The reporter traced `pg_autoctl show state --local` unlinking `pg_autoctl.pg` while a real keeper was running, racing its own writes and eventually escalating to a `pg_basebackup`:

```
T0+0.13s  openat(O_CREAT) pg_autoctl.pg by `pg_autoctl: node active`
T0+0.18s  unlink pg_autoctl.pg by `pg_autoctl show state --json --local`
T0+9.4s   keeper write again
T0+10.2s  unlink again
...       30s unlink retry (ENOENT after first attempt)
T0+30s    keeper timeout -> pg_basebackup
```

Confirmed against current `main`: `cli_show_state()`'s `--local` path calls `keeper_init()`, which unconditionally calls `local_postgres_init()` -> `local_postgres_set_status_path(postgres, true)` -- the `true` is `unlink`, hardcoded at the call site. `pg_autoctl.pg` is the postgres controller sub-process's only signal for whether Postgres is expected to be running or stopped (`service_postgres_ctl.c`'s main loop reads it every ~100ms). Deleting it is the right thing to do when a process is about to actually take over managing Postgres -- the real keeper does this on its own startup, and so do the ~20 other CLI commands that go through `keeper_init()` for legitimate state-changing operations (`enable`/`disable maintenance`, `node drop`, etc). `show state --local` does none of that: its entire purpose is a read-only, no-monitor-round-trip peek at local state, avoiding exactly the kind of side effect this turned out to have.

Worth noting: the *default* `pg_autoctl show state` (no `--local`) never touches any of this -- it just queries the monitor via SQL. `--local` exists specifically to skip that round-trip, so it's the "safer-looking" option that turns out to have the side effect. It's also silently forced for any node with `--disable-monitor` set, so those deployments hit this on every `show state` call, no flag needed.

## Fix

Two new, narrowly-scoped entry points that skip the unlink:
- `local_postgres_init_read_only()` in `primary_standby.c`/`.h`
- `keeper_init_read_only()` in `keeper.c`/`.h`

`cli_show.c`'s `--local` path now calls `keeper_init_read_only()` instead of `keeper_init()`. Every other one of `keeper_init()`'s ~20 existing callers is untouched -- `keeper_init()` itself keeps its exact current behavior.

## Verification

- Clean build, `make docker-check` (citus_indent) and `ci/banned.h.sh` both clean.
- Reproduced the exact race by hand in a running container: planted a stand-in `pg_autoctl.pg`, ran `show state --local` against `main`, confirmed it got deleted; same steps against this branch, file survives untouched.
- Added a permanent regression step, `basic_operation.pgaf::test_003_show_state_local_is_read_only`, doing the same plant-and-check through pgaftest. Full spec run: 28/28.

I didn't reproduce the full escalation to `pg_basebackup` end-to-end -- that needs the two commands racing with the right timing against a live FSM transition, which is hard to manufacture deterministically -- so this is verified at the level of the actual bug (the file getting deleted), not the full downstream consequence.
