### PR TITLE
Fix #1122: pg_autoctl config check swapped PID and port in log message

### DIFF
--- a/src/bin/pg_autoctl/cli_config.c
+++ b/src/bin/pg_autoctl/cli_config.c
@@ -268,7 +268,7 @@ cli_config_check_pgsetup(PostgresSetup *pgSetup)
 
 	log_info("Postgres setup for PGDATA \"%s\" is ok, "
 			 "running with PID %d and port %d",
-			 pgSetup->pgdata, pgSetup->pidFile.port, pgSetup->pidFile.pid);
+			 pgSetup->pgdata, pgSetup->pidFile.pid, pgSetup->pidFile.port);
 }
 
 


### PR DESCRIPTION
Fixes #1122.

## Bug

`pg_autoctl config check` builds its "Postgres setup ... is ok" log line with the format string `"running with PID %d and port %d"`, but passes the two values in the wrong order (`pidFile.port` then `pidFile.pid`). So the printed "PID" is actually the port and the printed "port" is actually the PID -- exactly what both reporters observed.

## Fix

One-line swap in `cli_config_check_pgsetup()` ([cli_config.c](src/bin/pg_autoctl/cli_config.c)) to pass `pidFile.pid, pidFile.port`, matching the format string and the `PostgresPIDFile` struct's own field order.

## Verification

- `citus_indent` (Docker) and `ci/banned.h.sh` both clean.
- Clean build (`-Wformat -Wall -Werror`, no warnings).
- Reproduced the exact reported values in isolation (PID 47546, port 5432) and confirmed the fixed format call now prints them in the right slots.
