### PR TITLE
monitor: enable server-side TCP keepalives + tcp_user_timeout (#1028)

### DIFF
--- a/src/bin/pg_autoctl/defaults.h
+++ b/src/bin/pg_autoctl/defaults.h
@@ -83,6 +83,42 @@
  */
 #define POSTGRES_MONITOR_TCP_USER_TIMEOUT "10000"
 
+/*
+ * Server-side TCP keepalives for the monitor's own Postgres instance
+ * (postgresql.conf, applies to every backend it accepts -- notably the
+ * long-lived LISTEN/NOTIFY connections nodes keep open to react to state
+ * changes). The client-side keepalives above bound how long the *keeper*
+ * waits before it notices a dead monitor connection and reconnects; they do
+ * nothing for the monitor's side of that same TCP pair. Without a
+ * server-side equivalent, a connection that goes silently half-open (a NAT
+ * or firewall dropping its idle mapping without ever sending a FIN/RST to
+ * either side -- observed after ordinary "network lag", not a hard
+ * partition) leaves an orphaned backend idle in pg_stat_activity
+ * indefinitely: neither idle_session_timeout nor
+ * client_connection_check_interval catch this, since both are passive (is
+ * there data to read?) rather than an active probe (issue #1028, backends
+ * observed idle for 8+ days).
+ *
+ * keepalives_idle is deliberately short enough to double as prevention, not
+ * just detection: a keepalive exchange every 30s means the connection never
+ * actually goes idle long enough, from the network's point of view, to hit
+ * most NAT/firewall inactivity timeouts in the first place. When a peer
+ * really is gone, worst-case detection is keepalives_idle +
+ * keepalives_interval * keepalives_count =~ 90 seconds, vs. the OS default
+ * of multiple hours (or effectively forever, on a path that never returns a
+ * hard error) -- an orphaned backend can no longer accumulate for days.
+ */
+#define POSTGRES_MONITOR_SERVER_TCP_KEEPALIVES_IDLE "30"
+#define POSTGRES_MONITOR_SERVER_TCP_KEEPALIVES_INTERVAL "10"
+#define POSTGRES_MONITOR_SERVER_TCP_KEEPALIVES_COUNT "6"
+
+/*
+ * Milliseconds. Same rationale as POSTGRES_MONITOR_TCP_USER_TIMEOUT above,
+ * server-side: bounds the case where the monitor has unacknowledged data
+ * still in flight to a now-unreachable node when the network disappears.
+ */
+#define POSTGRES_MONITOR_SERVER_TCP_USER_TIMEOUT "60000"
+
 
 /*
  * Microsoft approved cipher string.

--- a/src/bin/pg_autoctl/monitor_pg_init.c
+++ b/src/bin/pg_autoctl/monitor_pg_init.c
@@ -55,6 +55,16 @@ GUC monitor_default_settings[] = {
 	{ "ssl_cert_file", "" },
 	{ "ssl_key_file", "" },
 	{ "ssl_ciphers", "'" DEFAULT_SSL_CIPHERS "'" },
+
+	/*
+	 * Detect (and mostly prevent) nodes' connections silently going
+	 * half-open -- see the comment at POSTGRES_MONITOR_SERVER_TCP_KEEPALIVES_IDLE
+	 * in defaults.h for the full rationale (issue #1028).
+	 */
+	{ "tcp_keepalives_idle", POSTGRES_MONITOR_SERVER_TCP_KEEPALIVES_IDLE },
+	{ "tcp_keepalives_interval", POSTGRES_MONITOR_SERVER_TCP_KEEPALIVES_INTERVAL },
+	{ "tcp_keepalives_count", POSTGRES_MONITOR_SERVER_TCP_KEEPALIVES_COUNT },
+	{ "tcp_user_timeout", POSTGRES_MONITOR_SERVER_TCP_USER_TIMEOUT },
 #ifdef TEST
 	{ "unix_socket_directories", "''" },
 #endif


### PR DESCRIPTION
## Background

Fixes #1028, "Hung (unclosed) old connections in idle status on the monitor from datanodes". The reporter found backends accumulating on the monitor -- some 8+ days old, `idle`, `application_name = pgautofailover_standby_N`, `query = LISTEN "state"` (the long-lived LISTEN/NOTIFY connection every node keeps open to react to state changes). Root-caused it themselves: an ordinary network lag during connect, the node reconnects fine on a fresh connection, but the *old* one on the monitor is never cleaned up. They tried `idle_session_timeout` and `client_connection_check_interval` -- neither helped -- and worked around it with a `pg_cron` job force-killing idle `autoctl_node` backends older than 3 hours. The issue was closed with no comments and no linked commit/PR; nothing in the codebase addressed it.

## Root cause

Both settings the reporter tried are *passive* checks (is there data to read on the socket?). The actual failure mode here is a connection that's gone silently half-open: a NAT or firewall drops the idle mapping without ever sending a FIN or RST to either side. Passive checks have nothing to notice -- there's no data expected on an idle LISTEN connection either way. What's needed is an *active* probe: real TCP keepalives, which is a different mechanism entirely.

An earlier, unrelated fix (#1177, already merged) added client-side TCP keepalives + `tcp_user_timeout` to the keeper's connections to the monitor (`pgsql_open_connection()` in `src/bin/common/pgsql.c`, for `PGSQL_CONN_MONITOR` connections, which includes the notification/LISTEN connection too). That bounds how long the *keeper* waits before noticing a dead connection and reconnecting -- but those settings only configure the client's end of the socket. They do nothing for the *monitor's* side of that same TCP pair, which is what #1028 is actually about: the orphaned backend lives on the monitor, and only the monitor's own kernel can decide to reap it.

## Fix

Add the server-side equivalent: `tcp_keepalives_idle`, `tcp_keepalives_interval`, `tcp_keepalives_count`, and `tcp_user_timeout` as default settings in the monitor's own `postgresql.conf`, via `monitor_default_settings[]` in `monitor_pg_init.c` -- the same mechanism already used for the existing ssl/logging defaults, applied at `pg_autoctl create monitor` time.

`keepalives_idle` is set short (30s) deliberately, to double as *prevention* and not just detection: a keepalive exchange every 30s means the connection never actually goes idle long enough, from the network's point of view, to hit most NAT/firewall inactivity timeouts in the first place -- most of the time this should stop the underlying condition from happening at all, not just clean up after it. When a peer really is gone, worst-case detection is `keepalives_idle + keepalives_interval * keepalives_count` =~ 90 seconds, vs. the OS default of multiple hours (or effectively forever, on a path that never returns a hard error) -- an orphaned backend can no longer accumulate for days.

Values chosen to be a full explanation of what to expect are documented inline at `POSTGRES_MONITOR_SERVER_TCP_KEEPALIVES_IDLE` in `defaults.h`.

**Scope note**: like the other defaults in `monitor_default_settings[]`, this only applies to monitors created after this change (`pg_autoctl create monitor`) -- it doesn't retroactively patch `postgresql.conf` on an existing monitor. Anyone hitting #1028 today on an existing install can add the same four settings to their monitor's `postgresql.conf` by hand and reload.

## Verification

- `make docker-check` (citus_indent) and `ci/banned.h.sh`: both clean.
- `make -C src/bin/pg_autoctl`: clean build, zero warnings.
- Created a fresh monitor locally and confirmed all four settings land correctly in `postgresql-auto-failover.conf` and are picked up by the running server (`SHOW` / `pg_settings`) -- `tcp_keepalives_idle/_interval/_count` all applied correctly. `tcp_user_timeout` showed `0` in this local check specifically because it's a Linux-only socket option (`TCP_USER_TIMEOUT`) and that check ran on macOS -- Postgres accepts the GUC syntax everywhere but only actually applies it on platforms that support the underlying `setsockopt`, which is expected/correct, not a bug.
- Rebuilt the real Linux docker image (`make build-pg17`, includes a full `make installcheck` pass as part of the build -- 6/6 tests) and confirmed on that target: `tcp_user_timeout = 60000` (not 0), sourced from `configuration file`, alongside the three keepalive settings -- the actual deployment platform applies all four correctly.
- `pgaftest run tests/tap/specs/basic_operation.pgaf`: 28/28, including maintenance-mode, multiple manual failovers, and the 87s `test_022_detect_network_partition` scenario -- no regression from the new monitor GUCs.
- Brought up the same cluster interactively and confirmed the LISTEN "state"/"log" connections still show up normally in `pg_stat_activity`, cluster fully operational.
