### PR TITLE
runprogram: ignore SIGHUP around external subprocesses to stop reload signals killing them

### DIFF
--- a/src/bin/lib/subcommands.c/runprogram.h
+++ b/src/bin/lib/subcommands.c/runprogram.h
@@ -7,6 +7,7 @@
  */
 
 #include <fcntl.h>
+#include <signal.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -182,6 +183,8 @@ execute_subprogram(Program *prog)
 	pid_t pid;
 	int outpipe[2] = { 0, 0 };
 	int errpipe[2] = { 0, 0 };
+	struct sigaction ignoreHup = { 0 };
+	struct sigaction oldHupAction = { 0 };
 
 	/* first level sanity check */
 	if (access(prog->program, F_OK | X_OK) == -1)
@@ -217,6 +220,28 @@ execute_subprogram(Program *prog)
 		}
 	}
 
+	/*
+	 * A caller (e.g. a long-running pg_autoctl service) may receive a
+	 * config-reload SIGHUP at any moment, including while we're blocked
+	 * here waiting on this child. SIGHUP's default disposition is to
+	 * terminate the receiving process, and that default applies to the
+	 * external program we're about to exec() (openssl, pg_basebackup,
+	 * pg_ctl, ...) regardless of whatever handler our caller has installed
+	 * for itself -- only an *ignored* signal survives exec(), a handler
+	 * function does not. Without this, a reload landing mid-subprocess
+	 * kills that subprocess outright (observed: "openssl failed with
+	 * return code: 129", 128+SIGHUP, during node registration racing a
+	 * concurrent `pg_autoctl set node metadata`).
+	 *
+	 * Ignore SIGHUP here, before fork(), so the child inherits the ignored
+	 * disposition through both fork() and exec(): the external program can
+	 * no longer be killed by a reload signal that has nothing to do with
+	 * it. Restored once the child is done, so our own SIGHUP handling
+	 * resumes normally afterward.
+	 */
+	ignoreHup.sa_handler = SIG_IGN;
+	sigaction(SIGHUP, &ignoreHup, &oldHupAction);
+
 	pid = fork();
 
 	switch (pid)
@@ -226,6 +251,7 @@ execute_subprogram(Program *prog)
 			/* fork failed */
 			prog->returnCode = -1;
 			prog->error = errno;
+			sigaction(SIGHUP, &oldHupAction, NULL);
 			return;
 		}
 
@@ -310,6 +336,8 @@ execute_subprogram(Program *prog)
 			{
 				(void) waitprogram(prog, pid);
 			}
+
+			sigaction(SIGHUP, &oldHupAction, NULL);
 			return;
 		}
 	}


### PR DESCRIPTION
## Background

Surfaced by an intermittent CI failure on `pgaftest / node (PG19)`, specifically `tests/tap/specs/launch_deferred_set_metadata.pgaf::test_003_node_start`, first seen on PR #1180 (unrelated change -- monitor-side TCP keepalives) and confirmed to be a pre-existing race rather than a regression from that PR (the identical schedule had passed cleanly on PR #1179 moments earlier with materially the same code).

## Root cause

```
node2-1 | ... 11 INFO   /usr/bin/openssl req -new -x509 ... -subj "/CN=node2"
node2-1 | ... 8 INFO  pg_autoctl received a SIGHUP signal, reloading configuration
node2-1 | ... 8 INFO  Reloading service "node-init" by signaling pid 11 with SIGHUP
node2-1 | ... 11 ERROR openssl failed with return code: 129
node2-1 | ... 11 ERROR Failed to create SSL self-signed certificate, see above for details
node2-1 | ... 11 ERROR Failed to transition from state "wait_standby" to state "catchingup", see above.
```

129 = 128 + `SIGHUP` (signal 1) -- `openssl` was killed outright. This happened while node2's "node-init" service (still registering/catching up, per the spec's "launch deferred: create-immediate, run-deferred" scenario) was mid-flight generating its own standby SSL certificate, at the exact moment `test_002_set_metadata`'s `pg_autoctl set node metadata --name node_b` (run moments earlier, while node2 was still registering) delivered a config-reload `SIGHUP` via `supervisor_reload_services()`.

The underlying issue: `SIGHUP`'s default disposition is to terminate the receiving process. That default applies to *any* external program `pg_autoctl` shells out to (`openssl`, `pg_basebackup`, `pg_ctl`, `pg_controldata`, ...) just as much as to a bare pg_autoctl CLI invocation -- and critically, **only an *ignored* signal survives `exec()`; an installed handler function does not**. So no matter what SIGHUP handling the calling service has set up for itself, that protection is stripped away the instant it `exec()`s an external tool. A reload landing in that window kills the subprocess outright.

This is the same class of bug already fixed once in this codebase, for a different case: `cli_pg_autoctl_reload()` in `cli_common.c` already does `signal(SIGHUP, SIG_IGN)` on itself before signaling the daemon, with a comment explaining exactly this: "one-shot commands don't install a SIGHUP handler ... the default disposition (terminate) would kill us" (a PID-reuse scenario). That fix protected pg_autoctl's *own* one-shot CLI commands. It never covered external subprocesses spawned via `run_program()`, which had no equivalent protection at all.

## Fix

`execute_subprogram()` in `src/bin/lib/subcommands.c/runprogram.h` -- the single shared implementation every `run_program()` call in the codebase goes through (openssl, pg_basebackup, pg_ctl, pg_controldata, etc.) -- now sets `SIGHUP` to `SIG_IGN` immediately before `fork()`, and restores the caller's original disposition once the child has been reaped (or immediately, if `fork()` itself failed).

Because an *ignored* signal (unlike a handler) survives both `fork()` and `exec()`, the external program inherits immunity to a reload signal that has nothing to do with it -- closing the vulnerability at its root, regardless of the exact timing or delivery path of any particular SIGHUP. This is a single, minimal change in the shared library rather than patching each call site individually.

`execute_program()` (the sibling function that replaces the *current* process image for re-exec'ing `pg_autoctl internal service X`) is untouched -- that path hands off to a fresh pg_autoctl instance which installs its own proper SIGHUP handling on startup, so it doesn't need this protection.

## Verification

- `ci/banned.h.sh`: clean. (`src/bin/lib/subcommands.c/**` is explicitly excluded from `citus_indent` via `.gitattributes` -- vendored third-party code, same as `src/bin/lib/parson`, `log`, `pg`, etc.)
- `make -C src/bin/pg_autoctl`: clean build, zero warnings.
- `pgaftest run tests/tap/specs/launch_deferred_set_metadata.pgaf` x8 back-to-back: all green (the spec that failed intermittently in CI).
- `pgaftest run --schedule tests/tap/schedules/node.sch` (the exact CI schedule that showed "12/13 passed"): 13/13 passed, including `launch_deferred_set_metadata`.

**Caveat**: this is a timing-dependent race that only reproduced once across many CI runs. Repeated clean local runs are reassuring but can't prove the race is gone by brute force alone -- the confidence here comes from the fix closing the mechanism at the POSIX signal-semantics level (an ignored signal cannot terminate the process, full stop), not from having reproduced and then failed to reproduce the exact original interleaving.
