### PR TITLE
Makefile: fix docker-check/docker-indent from a git worktree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,16 @@ We format all our code using the coding conventions in the
 tool. This tool uses uncrustify under the hood. To format the python test files
 we use [black](https://github.com/psf/black).
 
+If you have Docker available, the simplest way to check or fix formatting
+locally, without installing anything, is:
+
+```bash
+make docker-check    # check only -- matches CI's citus_indent --check exactly
+make docker-indent   # auto-fix
+```
+
+Otherwise, install citus_indent locally:
+
 ```bash
 # Uncrustify changes the way it formats code every release a bit. To make sure
 # everyone formats consistently we use version 0.68.1:

--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,20 @@ test ci-test run-test run-test-prebuilt:
 # To check or auto-fix locally without installing citus_indent:
 #   make docker-check    # check only
 #   make docker-indent   # auto-fix
+#
+# citus_indent calls `git ls-files` to find the files it should look at, so
+# the container needs a working .git. In a plain checkout that's already
+# true (.git lives under $(CURDIR), which is mounted at /workdir). In a git
+# worktree, $(CURDIR)/.git is only a pointer file ("gitdir: <main-repo>/.git/
+# worktrees/<name>") to a path outside $(CURDIR) -- GIT_COMMON_DIR resolves
+# that pointer on the host and the extra -v mounts it into the container at
+# the identical absolute path, so it still resolves there too. This is a
+# harmless no-op for a plain checkout (it just mounts $(CURDIR)/.git over
+# itself).
+GIT_COMMON_DIR := $(shell cd "$(CURDIR)" && cd "$$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
 CITUS_INDENT_DOCKER = docker run --rm \
 	-v "$(CURDIR):/workdir" \
+	$(if $(GIT_COMMON_DIR),-v "$(GIT_COMMON_DIR):$(GIT_COMMON_DIR)") \
 	-w /workdir \
 	citus/stylechecker:no-py \
 	citus_indent


### PR DESCRIPTION
## Summary

`make docker-check`/`make docker-indent` (the documented way to run
citus_indent locally without installing it) failed when run from a git
worktree:

```
fatal: not a git repository: <main-repo>/.git/worktrees/<name>
fatal: not a git repository: <main-repo>/.git/worktrees/<name>
could not list files under source control
```

citus_indent calls `git ls-files` to find which files to check. A
worktree's own `.git` is just a pointer file (`gitdir: <main-repo>/.git/
worktrees/<name>`) to a path outside the container's mounted volume, so
that call fails inside the container.

## Fix

Resolve the real common git dir on the host via `git rev-parse
--git-common-dir` and bind-mount it into the container at the identical
absolute path, so the worktree's pointer still resolves. This is a no-op
for a plain (non-worktree) checkout, where the common dir already lives
under the mounted source tree — verified both cases work.

Also documents the `make docker-check`/`make docker-indent` shortcut in
CONTRIBUTING.md, which previously only described installing citus_indent
locally.

## Verification

- `make docker-check` from both a plain checkout and a `git worktree`
  checkout — both pass (exit 0).
- `make docker-indent` — no unexpected reformatting.
- `ci/banned.h.sh` — unaffected, still passes.
