### PR TITLE
Fix the Citus tutorial spec, and two pgaftest bugs it exposed

### DIFF
--- a/docs/tutorial/citus_tutorial.pgaf
+++ b/docs/tutorial/citus_tutorial.pgaf
@@ -1,10 +1,14 @@
 # Citus cluster: one coordinator pair + three worker pairs, all with HA.
 #
 # Usage:
-#   pgaftest setup docs/tutorial/citus_tutorial.pgaf --tmux
+#   pgaftest tmux docs/tutorial/citus_tutorial.pgaf
 #
-# The setup block waits until every formation has a primary and a secondary.
-# With --tmux you immediately get:
+# or, without a tmux session:
+#
+#   pgaftest cluster setup docs/tutorial/citus_tutorial.pgaf
+#
+# The setup block waits until every group has a primary and a secondary.
+# With tmux you immediately get:
 #
 #   top    — docker compose logs -f  (live container output)
 #   middle — pg_autoctl watch        (all-node state dashboard)
@@ -16,11 +20,14 @@
 #   pg_autoctl show state \
 #       --monitor postgresql://autoctl_node@monitor/pg_auto_failover
 #
-#   # connect to the Citus coordinator
-#   psql -h coord0a -U postgres -d citus
+#   # connect to the Citus coordinator (database "demo", role "docker")
+#   psql -h coord0a -d demo
+#
+#   # the workers, as Citus itself sees them
+#   psql -h coord0a -d demo -c 'select * from pg_dist_node'
 #
 #   # trigger a coordinator failover
-#   pg_autoctl perform failover --formation coord \
+#   pg_autoctl perform failover --group 0 \
 #       --monitor postgresql://autoctl_node@monitor/pg_auto_failover
 #
 #   # trigger a worker failover in group 1
@@ -28,17 +35,31 @@
 #       --monitor postgresql://autoctl_node@monitor/pg_auto_failover
 #
 # When done:
-#   pgaftest down --work-dir /tmp/pgaftest/citus_tutorial
+#   pgaftest cluster down docs/tutorial/citus_tutorial.pgaf
+#
+# ONE FORMATION, NOT TWO. It is tempting to write this with a "coord"
+# formation and a "workers" formation, which reads better and does not
+# work: a Citus worker asks the monitor for the coordinator OF ITS OWN
+# FORMATION, so workers in a formation the coordinator is not in find
+# nothing, fail their init -> single transition, and pg_autoctl gives up
+# once its restart budget is spent. The symptom in the worker log is
+#
+#   ERROR Failed to get the coordinator node from the monitor: the monitor
+#   returned an empty result set, there's no known available coordinator
+#   node at this time in formation "workers"
+#
+# and the containers exit rather than retrying, so the cluster comes up
+# with a healthy coordinator pair and no workers at all. Coordinator and
+# workers belong in ONE formation, distinguished by group: group 0 is the
+# coordinator pair, groups 1..n are the worker pairs.
 
 cluster {
     monitor
 
-    formation coord {
-        coord0a  coordinator
-        coord0b  coordinator
-    }
+    formation num-sync 1 {
+        coord0a   coordinator
+        coord0b   coordinator
 
-    formation workers num-sync 1 {
         worker1a  worker  group 1
         worker1b  worker  group 1
         worker2a  worker  group 2
@@ -49,7 +70,10 @@ cluster {
 }
 
 setup {
-    wait until primary, secondary  timeout 180s
+    wait until primary, secondary in group 0  timeout 180s
+    wait until primary, secondary in group 1  timeout 180s
+    wait until primary, secondary in group 2  timeout 180s
+    wait until primary, secondary in group 3  timeout 180s
 }
 
 teardown {

--- a/src/bin/pgaftest/cli_root.c
+++ b/src/bin/pgaftest/cli_root.c
@@ -691,7 +691,7 @@ cli_show_state(int argc, char **argv)
 
 
 /* -----------------------------------------------------------------------
- * pgaftest down
+ * pgaftest cluster sh
  * ----------------------------------------------------------------------- */
 static void
 cli_sh(int argc, char **argv)
@@ -839,7 +839,7 @@ cli_run_setup_only(int argc, char **argv)
 	fformat(stdout,
 			"Try: pgaftest step"
 			"  |  pgaftest network disconnect <node>"
-			"  |  pgaftest show state  |  pgaftest down\n\n");
+			"  |  pgaftest show state  |  pgaftest cluster down\n\n");
 
 	/*
 	 * Replace this process with bash so the tmux pane becomes an
@@ -1198,7 +1198,7 @@ static CommandLine run_command =
 				 "                     (default: $TMPDIR/pgaftest/<testname>)\n"
 				 "  --no-cleanup       Leave the compose stack running after the\n"
 				 "                     run (pass or fail) for post-mortem inspection.\n"
-				 "                     Use `pgaftest down <spec.pgaf>` to clean up.\n"
+				 "                     Use `pgaftest cluster down <spec.pgaf>` to clean up.\n"
 				 "  --verbose          Enable DEBUG log level\n"
 				 "  --debug            Enable TRACE log level\n",
 				 pgaftest_getopts, cli_run);
@@ -1391,7 +1391,7 @@ static CommandLine compose_kill_command =
 
 static CommandLine compose_down_command =
 	make_command("down",
-				 "Tear down the compose stack (no teardown{} block; see `pgaftest down`)",
+				 "Tear down the compose stack (no teardown{} block; see `pgaftest cluster down`)",
 				 "",
 				 "",
 				 pgaftest_getopts, cli_compose_down);

--- a/src/bin/pgaftest/main.c
+++ b/src/bin/pgaftest/main.c
@@ -53,5 +53,21 @@ main(int argc, char **argv)
 		return 1;
 	}
 
-	return commandline_run(&pgaftest_root, argc, argv);
+	/*
+	 * commandline_run() returns a BOOL: false when parsing failed (unknown
+	 * command, missing subcommand), true otherwise. Returning it directly as
+	 * the exit status inverted the meaning -- an unknown command produced
+	 * "unknown command" on stderr and then exited 0, so
+	 *
+	 *     pgaftest down --work-dir ... && echo ok
+	 *
+	 * printed the error AND "ok". Scripts and CI could not tell a typo from
+	 * a successful run. Same shape as pg_autoctl's own main().
+	 */
+	if (!commandline_run(&pgaftest_root, argc, argv))
+	{
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	return 0;
 }

--- a/src/bin/pgaftest/test_runner.c
+++ b/src/bin/pgaftest/test_runner.c
@@ -5046,7 +5046,7 @@ runner_setup(TestSpec *spec, const char *workDir, bool withTmux)
 			fformat(stdout, " %s", s->name);
 		}
 		fformat(stdout, "\n\nRun a step: pgaftest step <name> --work-dir %s\n", workDir);
-		fformat(stdout, "Tear down:  pgaftest down --work-dir %s\n\n", workDir);
+		fformat(stdout, "Tear down:  pgaftest cluster down --work-dir %s\n\n", workDir);
 	}
 
 	return true;


### PR DESCRIPTION
`docs/tutorial/citus_tutorial.pgaf` brings up a coordinator pair and no workers at all. Found while using it to build a Citus cluster for a course chapter; the two `pgaftest` bugs in the second commit are what made it hard to notice.

## 1. The tutorial spec cannot start its workers

The spec puts the coordinator in a `coord` formation and the workers in a `workers` formation. That reads well and does not work: a Citus worker asks the monitor for the coordinator **of its own formation**, so every worker gets an empty result set, fails its `init` → `single` transition, and `pg_autoctl` exits once its restart budget is spent — five restarts in eight seconds.

```
ERROR Failed to get the coordinator node from the monitor: the monitor returned
      an empty result set, there's no known available coordinator node at this
      time in formation "workers"
ERROR Failed to transition from state "init" to state "single", see above.
FATAL pg_autoctl service node-active has already been restarted 5 times in the
      last 8 seconds, stopping now
```

The failure is quiet in the worst way. `pgaftest cluster setup` reports **"Cluster ready"**, the coordinator pair genuinely is healthy, and `pg_dist_node` lists exactly one node:

```
$ docker exec citus_tutorial-coord0a-1 psql -d demo -tAc \
      'select nodename, groupid, noderole from pg_dist_node order by nodeid'
coord0a|0|primary
```

It looks like a Citus problem. It is a spec problem.

**Fix:** coordinator and workers share one formation, distinguished by group — group 0 for the coordinator pair, 1..3 for the workers. That is what `tests/tap/specs/citus_basic_operation.pgaf` has always done, which is presumably why the tests pass while the tutorial does not.

Verified end to end — all eight nodes reach primary/secondary:

```
coord0a|0|primary      worker1a|1|primary     worker2a|2|primary     worker3a|3|primary
coord0b|0|secondary    worker1b|1|secondary   worker2b|2|secondary   worker3b|3|secondary
```

and Citus sees all three workers. I then distributed a partitioned table across the cluster and read the resulting plans, so it is genuinely usable, not just green in the monitor.

Also in that commit:

- **Stale commands in the header.** `pgaftest setup <spec> --tmux` → `pgaftest tmux <spec>`; `pgaftest down --work-dir ...` → `pgaftest cluster down <spec>`.
- **`setup{}` gains per-group waits.** It previously waited on `primary, secondary` without a group, so it returned while the workers were still in `init` — part of why the failure looked like success.
- **Real connection details:** database `demo`, role `docker`. There is no `postgres` role in these images, so the old `psql -h coord0a -U postgres -d citus` failed twice over.
- A long comment explaining the one-formation rule, because this is a tutorial and the trap costs an hour to diagnose from the symptom.

## 2. `pgaftest` exits 0 on an unknown command

`main()` returned `commandline_run()`'s **bool** directly as the process exit status. That inverts the meaning — `commandline_run()` returns `false` when parsing failed:

```
$ pgaftest bogus-command ; echo "exit=$?"
pgaftest: bogus-command: unknown command
...
exit=0
```

So scripts and CI could not tell a typo from a successful run, and `pgaftest something-wrong && next-step` cheerfully ran `next-step`. Now shaped like `pg_autoctl`'s own `main()`: `if (!commandline_run(...)) exit(EXIT_CODE_BAD_ARGS);`

## 3. Four places still advertise `pgaftest down`

Which has not been a command for some time — it is `pgaftest cluster down`. The most visible is the hint printed at the end of a **successful** `pgaftest cluster setup`:

```
Tear down:  pgaftest down --work-dir /tmp/pgaftest/citus_tutorial
```

Copy that line, run it, and — because of bug 2 — it printed usage and exited 0, so it looked like it had worked while the stack stayed up. That is how the two bugs fed each other.

Fixed in `test_runner.c:5049` and in `cli_root.c`'s interactive-shell banner, `--no-cleanup` help text, and the `compose down` command description. A stale comment header for `cli_sh` said `pgaftest down` too; it is `pgaftest cluster sh`.

## Verification

The three touched C files compile clean under the project's `-Werror` flags. The full link needs the container build (the Makefile resolves shared sources through `/usr/src/pg_auto_failover`), so that part is left to CI.